### PR TITLE
Allow users to invoke apps by name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "clap",
  "dirs",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "crypto"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "base64",
  "pem",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "pem",
  "rsa",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "tower-api"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bytes",
  "chrono",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cli"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "tokio",
  "tower-api",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cmd"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "chrono",
  "clap",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tower-package"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-compression",
  "config",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "tower-runtime"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "clap",
  "dirs",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "crypto"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "base64",
  "pem",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "pem",
  "rsa",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "tower-api"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "bytes",
  "chrono",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "tokio",
  "tower-api",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cmd"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "chrono",
  "clap",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "tower-package"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-compression",
  "config",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "tower-runtime"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.19"
+version = "0.1.20"
 description = "Tower is the best way to host Python data apps in production"
 rust-version = "1.77"
 authors = ["Brad Heller <brad@tower.dev>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.18"
+version = "0.1.19"
 description = "Tower is the best way to host Python data apps in production"
 rust-version = "1.77"
 authors = ["Brad Heller <brad@tower.dev>"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :tokyo_tower: Tower CLI
+# Tower CLI
 
 The Tower CLI is one of the main ways to interact with the Tower environment.
 You can do basically everything you need inside the Tower CLI, including run

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -67,7 +67,7 @@ impl App {
                 }
             },
             Some(("deploy", args)) => {
-                deploy::do_deploy(config, client, args.subcommand()).await
+                deploy::do_deploy(config, client, args).await
             },
             Some(("run", args)) => {
                 run::do_run(config, client, args, args.subcommand()).await

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -77,7 +77,7 @@ pub fn config_error(err: config::Error) {
             "Couldn't read the Towerfile in this directory".to_string()
         },
         config::Error::MissingTowerfile => {
-            "No Towerfile was found in the current directory".to_string()
+            "No Towerfile was found in the target directory".to_string()
         },
         config::Error::MissingRequiredAppField { ref field } => {
             format!("Missing required app field `{}` in Towerfile", field)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tower-cli"
-version = "0.1.18"
+version = "0.1.19"
 description = "Tower CLI and runtime environment for Tower."
 authors = [{ name = "Tower Computing Inc.", email = "brad@tower.dev" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tower-cli"
-version = "0.1.19"
+version = "0.1.20"
 description = "Tower CLI and runtime environment for Tower."
 authors = [{ name = "Tower Computing Inc.", email = "brad@tower.dev" }]
 readme = "README.md"


### PR DESCRIPTION
The Tower CLI previously allowed you to supply an optional directory as an argument such that you could be build/deploy/run a Tower app from anywhere in your filesystem. We've pushed that into a named argument (`--dir`) such that you can invoke `tower run <app name>`.