### PR TITLE
Extract Schedule from Towerfile and propagate it to Tower

### DIFF
--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -61,6 +61,9 @@ pub struct PackageSpec {
 
     // parameters are the parameters to use for this app.
     pub parameters: Vec<Parameter>,
+
+    // schedule defines the frequency that this app should be run on.
+    pub schedule: Option<String>,
 }
 
 fn get_parameters(towerfile: &Towerfile) -> Vec<Parameter> {
@@ -78,8 +81,14 @@ fn get_parameters(towerfile: &Towerfile) -> Vec<Parameter> {
 impl PackageSpec {
     pub fn from_towerfile(towerfile: &Towerfile) -> Self {
         let base_dir = towerfile.base_dir.clone();
+        let schedule = if towerfile.app.schedule.is_empty() {
+            None
+        } else {
+            Some(towerfile.app.schedule.to_string())
+        };
 
         Self {
+            schedule,
             base_dir,
             invoke: towerfile.app.script.clone(),
             file_globs: towerfile.app.source.clone(),
@@ -100,9 +109,6 @@ pub struct Package {
 
     // unpacked_path is the path to the unpackaged package on disk.
     pub unpacked_path: Option<PathBuf>,
-
-    // schedule defines the frequency that this app should be run on.
-    pub schedule: Option<Schedule>,
 }
 
 impl Package {

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -30,7 +30,11 @@ pub struct Manifest {
     pub invoke: String,
 
     #[serde(default)]
-    pub parameters: Vec<Parameter>
+    pub parameters: Vec<Parameter>,
+
+    // schedule is the schedule that we want to execute this app on. this is, just temporarily,
+    // where it will live.
+    pub schedule: Option<String>,
 }
 
 impl Manifest {
@@ -96,6 +100,9 @@ pub struct Package {
 
     // unpacked_path is the path to the unpackaged package on disk.
     pub unpacked_path: Option<PathBuf>,
+
+    // schedule defines the frequency that this app should be run on.
+    pub schedule: Option<Schedule>,
 }
 
 impl Package {
@@ -108,6 +115,7 @@ impl Package {
                version: Some(CURRENT_PACKAGE_VERSION),
                invoke: "".to_string(),
                parameters: vec![],
+               schedule: None,
            },
        }
    }
@@ -172,6 +180,7 @@ impl Package {
            version: Some(CURRENT_PACKAGE_VERSION),
            invoke: String::from(spec.invoke),
            parameters: spec.parameters,
+           schedule: spec.schedule,
        };
 
        // the whole manifest needs to be written to a file as a convenient way to avoid having to

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+requires-python = ">=3.7"
+
+[[package]]
+name = "tower-cli"
+version = "0.1.20"
+source = { editable = "." }


### PR DESCRIPTION
This PR actually consumes the `schedule` attribute and forwards it to Tower as part of the manifest. This is a temporary solution, until we get more complete scheduling in place.