### PR TITLE
Remove ability to specify schedule at app create time

### DIFF
--- a/crates/tower-api/src/lib.rs
+++ b/crates/tower-api/src/lib.rs
@@ -49,7 +49,6 @@ struct ListAppsResponse {
 struct CreateAppRequest {
     name: String,
     short_description: String,
-    schedule: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -232,11 +231,10 @@ impl Client {
         Ok(res.app)
     }
 
-    pub async fn create_app(&self, name: &str, description: &str, schedule: &str) -> Result<App> {
+    pub async fn create_app(&self, name: &str, description: &str) -> Result<App> {
         let data = CreateAppRequest {
             name: String::from(name),
             short_description: String::from(description),
-            schedule: String::from(schedule),
         };
 
         let body = serde_json::to_value(data).unwrap();

--- a/crates/tower-cmd/src/apps.rs
+++ b/crates/tower-cmd/src/apps.rs
@@ -175,11 +175,10 @@ pub async fn do_create_app(_config: Config, client: Client, args: &ArgMatches) {
     });
 
     let description = args.get_one::<String>("description").unwrap();
-    let schedule = args.get_one::<String>("schedule").unwrap();
 
     let mut spinner = output::spinner("Creating app");
 
-    match client.create_app(&name, &description, &schedule).await {
+    match client.create_app(&name, &description).await {
         Ok(_app) => {
             spinner.success();
 

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -37,7 +37,7 @@ pub async fn do_deploy(_config: Config, client: Client, args: &ArgMatches) {
     match Towerfile::from_path(path) {
         Ok(towerfile) => {
             // Add app existence check before proceeding
-            if let Err(err) = util::ensure_app_exists(&client, &towerfile.app.name, &towerfile.app.description, &towerfile.app.schedule).await {
+            if let Err(err) = util::ensure_app_exists(&client, &towerfile.app.name, &towerfile.app.description).await {
                 output::tower_error(err);
                 return;
             }

--- a/crates/tower-cmd/src/util.rs
+++ b/crates/tower-cmd/src/util.rs
@@ -2,7 +2,7 @@ use tower_api::{Client, TowerError};
 use promptly::prompt_default;
 use crate::output;
 
-pub async fn ensure_app_exists(client: &Client, app_name: &str, description: &str, schedule: &str) -> Result<(), TowerError> {
+pub async fn ensure_app_exists(client: &Client, app_name: &str, description: &str) -> Result<(), TowerError> {
     match client.get_app(app_name).await {
         Ok(_) => Ok(()),
         Err(err) => {
@@ -10,7 +10,7 @@ pub async fn ensure_app_exists(client: &Client, app_name: &str, description: &st
                 if prompt_default(format!("App '{}' does not exist. Would you like to create it?", app_name), false)
                     .unwrap_or(false) 
                 {
-                    match client.create_app(app_name, description, schedule).await {
+                    match client.create_app(app_name, description).await {
                         Ok(_) => {
                             output::success(&format!("Created app '{}'", app_name));
                             Ok(())


### PR DESCRIPTION
It doesn't make sense to specify schedule outside of the app deployment flow. We don't allow you to specify schedule at when you create an app in the Tower app right now. We may in the future provide this feature, but until we think about that more holistically, let's not worry about this feature.

This resolves #11 as reported by @alitouka.
