### PR TITLE
Package the Towerfile with the bundle sent to Tower

### DIFF
--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -1,6 +1,6 @@
 use crate::Error;
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Deserialize)]
 pub struct Parameter{
@@ -34,10 +34,10 @@ pub struct App {
 
 #[derive(Deserialize)]
 pub struct Towerfile {
-    /// base_dir is the directory in which the Towerfile is located. It's always populated by the
+    /// file_path is the path to where this file was read on disk. It's always populated by the
     /// parser/application, never by the data.
     #[serde(skip_deserializing)]
-    pub base_dir: PathBuf,
+    pub file_path: PathBuf,
 
     pub app: App,
 
@@ -48,7 +48,7 @@ pub struct Towerfile {
 impl Towerfile {
     pub fn default() -> Self {
         Self {
-            base_dir: PathBuf::new(),
+            file_path: PathBuf::new(),
             parameters: vec![],
             app: App {
                 name: String::from(""),
@@ -79,8 +79,7 @@ impl Towerfile {
         }
 
         let mut towerfile = Self::from_toml(&std::fs::read_to_string(path.to_path_buf())?)?;
-        let parent = path.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
-        towerfile.base_dir = parent;
+        towerfile.file_path = path;
 
         Ok(towerfile)
     }

--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -190,7 +190,7 @@ mod test {
         file.write_all(toml.as_bytes()).unwrap();
 
         let towerfile = crate::Towerfile::from_local_file().expect("Failed to parse Towerfile");
-        assert_eq!(towerfile.base_dir, PathBuf::from("."));
+        assert_eq!(towerfile.file_path, PathBuf::from("./Towerfile"));
 
         // explicitly drop this file so it's cleaned up when other test cases run.
         drop(tempfile);
@@ -214,7 +214,7 @@ mod test {
         file.write_all(toml.as_bytes()).unwrap();
 
         let towerfile = crate::Towerfile::from_path(towerfile_path.clone()).unwrap();
-        assert_eq!(towerfile.base_dir, temp_dir);
+        assert_eq!(towerfile.file_path, temp_dir.join("Towerfile"));
 
         // explicitly drop this file so it's cleaned up when other test cases run.
         drop(tempfile);

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -45,6 +45,9 @@ pub fn package_error(err: tower_package::Error) {
         tower_package::Error::InvalidManifest => {
             "Invalid manifest was found or created".to_string()
         }
+        tower_package::Error::InvalidPath => {
+            "There was a problem determining exactly where your Towerfile was stored on disk".to_string()
+        }
     };
 
     let line = format!("{} {}\n", "Package error:".red(), msg);

--- a/crates/tower-package/src/error.rs
+++ b/crates/tower-package/src/error.rs
@@ -7,6 +7,9 @@ pub enum Error {
 
     #[snafu(display("Invalid manifest"))]
     InvalidManifest,
+
+    #[snafu(display("Invalid path"))]
+    InvalidPath,
 }
 
 impl From<std::io::Error> for Error {

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -209,6 +209,12 @@ impl Package {
        write_manifest_to_file(&manifest_path, &manifest).await?;
        builder.append_path_with_name(manifest_path, "MANIFEST").await?;
 
+       // Let's also package the Towerfile along with it.
+       builder.append_path_with_name(
+           spec.towerfile_path,
+           "Towerfile",
+       ).await?;
+
        // consume the builder to close it, then close the underlying gzip stream
        let mut file = builder.into_inner().await?;
        file.shutdown().await?;


### PR DESCRIPTION
This PR makes it such that we always package the Towerfile that we built the package from along with the rest of the content. This allows us to track changes to the Towerfile between deployments and all that. Obviously, on the services' side, the relevant content will be encrypted at rest.