### PR TITLE
Collect and forward Setup-related logs as well as program logs

### DIFF
--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -12,7 +12,7 @@ use tower_api::{
 };
 use tower_api::models;
 use tower_package::{Package, PackageSpec};
-use tower_runtime::{local::LocalApp, App, AppLauncher, OutputChannel};
+use tower_runtime::{local::LocalApp, App, AppLauncher, OutputReceiver};
 
 use crate::output;
 
@@ -330,7 +330,7 @@ async fn build_package(towerfile: &Towerfile) -> Package {
 
 /// monitor_output is a helper function that will monitor the output of a given output channel and
 /// plops it down on stdout.
-async fn monitor_output(output: OutputChannel) {
+async fn monitor_output(output: OutputReceiver) {
     loop {
         if let Some(line) = output.lock().await.recv().await {
             let ts = &line.time;

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -16,7 +16,10 @@ use crate::{
 use tokio::{
     sync::oneshot,
     sync::oneshot::error::TryRecvError,
-    sync::mpsc::channel,
+    sync::mpsc::{
+        UnboundedSender,
+        unbounded_channel,
+    },
     process::Command,
 };
 
@@ -25,7 +28,6 @@ use tokio::{
     io::{AsyncRead, BufReader, AsyncBufReadExt},
     time::{timeout, Duration},
     sync::Mutex,
-    sync::mpsc::Sender,
     process::Child, 
 };
 
@@ -33,9 +35,11 @@ use tower_package::{Manifest, Package};
 
 use crate::{
     FD,
+    Channel,
     App,
     Output,
-    OutputChannel,
+    OutputSender,
+    OutputReceiver,
 };
 
 pub struct LocalApp {
@@ -48,15 +52,22 @@ pub struct LocalApp {
     child: Option<Arc<Mutex<Child>>>,
     status: Option<Status>,
     waiter: Option<oneshot::Receiver<i32>>,
+
+    output_sender: OutputSender,
+    output_receiver: OutputReceiver,
 }
 
 impl Default for LocalApp {
     fn default() -> Self {
+        let (sender, receiver) = unbounded_channel::<Output>();
+
         Self {
             package: None,
             child: None,
             status: None,
             waiter: None,
+            output_sender: Arc::new(Mutex::new(sender)),
+            output_receiver: Arc::new(Mutex::new(receiver)),
         }
     }
 }
@@ -140,6 +151,11 @@ async fn find_bash() -> Result<PathBuf, Error> {
 
 impl App for LocalApp {
     async fn start(opts: StartOptions) -> Result<Self, Error> {
+        let (sender, receiver) = unbounded_channel::<Output>();
+
+        let output_sender = Arc::new(Mutex::new(sender));
+        let output_receiver = Arc::new(Mutex::new(receiver));
+
         let package = opts.package;
         let environment = opts.environment;
         let package_path = package.unpacked_path
@@ -198,6 +214,13 @@ impl App for LocalApp {
                 .spawn();
 
             if let Ok(mut child) = res {
+                // Let's also send our logs to this output channel.
+                let stdout = child.stdout.take().expect("no stdout");
+                tokio::spawn(drain_output(FD::Stdout, Channel::Setup, output_sender.clone(), BufReader::new(stdout)));
+
+                let stderr = child.stderr.take().expect("no stderr");
+                tokio::spawn(drain_output(FD::Stderr, Channel::Setup, output_sender.clone(), BufReader::new(stderr)));
+
                 // Wait for the child to complete entirely.
                 child.wait().await.expect("child failed to exit");
             }
@@ -228,6 +251,8 @@ impl App for LocalApp {
             tokio::spawn(wait_for_process(sx, Arc::clone(&child)));
 
             Ok(Self {
+                output_sender,
+                output_receiver,
                 package: Some(package),
                 child: Some(child),
                 waiter: Some(rx),
@@ -282,19 +307,17 @@ impl App for LocalApp {
         }
     }
 
-    async fn output(&self) -> Result<OutputChannel, Error> {
+    async fn output(&self) -> Result<OutputReceiver, Error> {
         if let Some(proc) = &self.child {
             let mut child = proc.lock().await;
 
-            let (sx, rx) = channel::<Output>(1);
-
             let stdout = child.stdout.take().expect("no stdout");
-            tokio::spawn(drain_output(FD::Stdout, sx.clone(), BufReader::new(stdout)));
+            tokio::spawn(drain_output(FD::Stdout, Channel::Program, self.output_sender.clone(), BufReader::new(stdout)));
 
             let stderr = child.stderr.take().expect("no stderr");
-            tokio::spawn(drain_output(FD::Stderr, sx.clone(), BufReader::new(stderr)));
+            tokio::spawn(drain_output(FD::Stderr, Channel::Program, self.output_sender.clone(), BufReader::new(stderr)));
 
-            Ok(Arc::new(Mutex::new(rx)))
+            Ok(self.output_receiver.clone())
         } else {
             Err(Error::NoRunningApp)
         }
@@ -441,15 +464,18 @@ async fn wait_for_process(sx: oneshot::Sender<i32>, proc: Arc<Mutex<Child>>) {
     let _ = sx.send(code);
 }
 
-async fn drain_output<R: AsyncRead + Unpin>(fd: FD, output: Sender<Output>, input: BufReader<R>) {
+async fn drain_output<R: AsyncRead + Unpin>(fd: FD, channel: Channel, output: Arc<Mutex<UnboundedSender<Output>>>, input: BufReader<R>) {
     let mut lines = input.lines();
 
     while let Some(line) = lines.next_line().await.expect("line iteration fialed") {
+        let output = output.lock().await;
+
         let _ = output.send(Output{ 
+            channel,
             fd,
             line,
             time: chrono::Utc::now(),
-        }).await;
+        });
     }
 }
 

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -207,6 +207,9 @@ impl App for LocalApp {
 
             let res = Command::new(pip_path)
                 .current_dir(&working_dir)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
                 .arg("install")
                 .arg("-r")
                 .arg(package_path.join("requirements.txt"))
@@ -220,6 +223,8 @@ impl App for LocalApp {
 
                 let stderr = child.stderr.take().expect("no stderr");
                 tokio::spawn(drain_output(FD::Stderr, Channel::Setup, output_sender.clone(), BufReader::new(stderr)));
+
+                log::debug!("waiting for dependency installation to complete");
 
                 // Wait for the child to complete entirely.
                 child.wait().await.expect("child failed to exit");


### PR DESCRIPTION
This PR introduces the ability for setup-related logs to be collected and forwarded. It slightly changes the semantics of log collection, too, by starting the log collection process even before the calling programs ask for log output. It buffers all logs in memory 'till they start getting pulled out.