### PR TITLE
Introduce `workspace` attribute in Towerfile

### DIFF
--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -30,6 +30,9 @@ pub struct App {
 
     #[serde(default)]
     pub description: String,
+
+    #[serde(default)]
+    pub workspace: PathBuf,
 }
 
 #[derive(Deserialize)]
@@ -56,6 +59,7 @@ impl Towerfile {
                 source: vec![],
                 schedule: String::from("0 0 * * *"),
                 description: String::from(""),
+                workspace: PathBuf::new(),
             },
         }
     }
@@ -63,7 +67,16 @@ impl Towerfile {
     /// from_toml parses a new Towerfile from a TOML string. It's not exposed externally because
     /// the base_dir field always needs to be set after parsing.
     pub fn from_toml(toml: &str) -> Result<Self, Error> {
-        let towerfile: Towerfile = toml::from_str(toml)?;
+        let mut towerfile: Towerfile = toml::from_str(toml)?;
+
+        // We set the workspace to the directory of the Towerfile if it's not set because that's
+        // the implicit behavior overall for legacy Towerfiles.
+        if towerfile.app.workspace.as_os_str().is_empty() {
+            towerfile.app.workspace = towerfile.file_path
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| PathBuf::new());
+        }
 
         if towerfile.app.name.is_empty() {
             return Err(Error::MissingRequiredAppField{ field: "name".to_string() });

--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -259,4 +259,19 @@ mod test {
         assert_eq!(towerfile.parameters[0].name, "my_first_param");
         assert_eq!(towerfile.parameters[1].name, "my_second_param");
     }
+
+    #[test]
+    fn test_parsing_workspaces() {
+        let toml = r#"
+            [app]
+            name = "my-app"
+            script = "my-app/script.py"
+            source = ["*.py"]
+            workspace = "../"
+        "#;
+
+        // All we want need to do is to ensure that the workspace is set accordingly.
+        let towerfile = crate::Towerfile::from_toml(toml).unwrap();
+        assert_eq!(towerfile.app.workspace, PathBuf::from("../"));
+    }
 }

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -84,10 +84,8 @@ fn get_parameters(towerfile: &Towerfile) -> Vec<Parameter> {
 impl PackageSpec {
     pub fn from_towerfile(towerfile: &Towerfile) -> Self {
         let towerfile_path = towerfile.file_path.clone();
-        let base_dir = towerfile_path
-            .parent()
-            .expect("Towerfile must have a parent directory")
-            .to_path_buf();
+        let base_dir = towerfile.app.workspace.clone();
+
         let schedule = if towerfile.app.schedule.is_empty() {
             None
         } else {
@@ -153,13 +151,9 @@ impl Package {
    // The underlying package is just a TAR file with a special `MANIFEST` file that has also been
    // GZip'd.
    pub async fn build(spec: PackageSpec) -> Result<Self, Error> {
-       // We expand the base_dir because handling the paths as absolute paths is easier than
-       // handling them as relative paths.
-       let base_dir = spec.towerfile_path.
-           canonicalize()?.
-           parent().
-           ok_or(Error::InvalidPath)?.
-           to_path_buf();
+       // we canonicalize this because we want to treat all paths in the same keyspace more or
+       // less.
+       let base_dir = spec.base_dir.canonicalize()?;
 
        let tmp_dir = TmpDir::new("tower-package").await?;
        let package_path = tmp_dir.to_path_buf().join("package.tar");


### PR DESCRIPTION
This allows us to share code by virtue of the fact that an app can exist within a workspace of many apps and shared code. The workspace attribute basically tells the Tower CLI what the base directory is for building the overall package.