### PR TITLE
Release v0.3.20

### DIFF
--- a/crates/tower-api/src/models/mod.rs
+++ b/crates/tower-api/src/models/mod.rs
@@ -202,6 +202,8 @@ pub mod run_log_line;
 pub use self::run_log_line::RunLogLine;
 pub mod run_parameter;
 pub use self::run_parameter::RunParameter;
+pub mod run_results;
+pub use self::run_results::RunResults;
 pub mod run_statistics;
 pub use self::run_statistics::RunStatistics;
 pub mod run_timeseries_point;


### PR DESCRIPTION
- Upgrade the Tower API
- Move to rustls instead of native TLS
- Bump version to v0.3.20