### PR TITLE
Add flake.nix file to support nix ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,63 @@ $ pip install -U tower
 
 You can also download the CLI directly from one of our [releases](https://github.com/tower/tower-cli/releases/latest).
 
+### Nix Flake
+
+If you have Nix installed with flakes enabled, you can install the latest version
+of tower CLI with the following:
+
+#### Profile
+
+```bash
+$ nix profile install github:tower/tower-cli#tower
+```
+
+#### NixOS/nix-darwin
+
+If you are using [NixOS]()/[nix-darwin](https://github.com/nix-darwin/nix-darwin)
+with flakes then you can add the following:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    tower-cli.url = "github:tower/tower-cli";
+  };
+
+  outputs = { self, nixpkgs, tower-cli, ... }@inputs: {
+    # with nix-darwin:
+    # darwinConfigurations.your-hostname = darwin.lib.darwinSystem {
+    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [{
+        environment.systemPackages = [ tower-cli.packages.${system}.tower ];
+      }];
+    };
+  };
+}
+```
+
+#### Devenv
+
+If you're using [devenv](https://devenv.sh), you can add tower-cli to your project:
+
+```yaml
+# devenv.yaml
+inputs:
+  tower-cli:
+    url: github:tower/tower-cli
+```
+
+```nix
+# devenv.nix
+{ inputs, pkgs, ... }:
+{
+  packages = [
+    inputs.tower-cli.packages.${pkgs.stdenv.system}.tower
+  ];
+}
+```
+
 ## Using the Tower CLI
 
 There are two big components in the Tower CLI reposiory: The CLI itself and the

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,121 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1751352216,
+        "narHash": "sha256-dJj8TUoZGj55Ttro37vvFGF2L+xlYNfspQ9u4BfqTFw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "61b4f1e21bd631da91981f1ed74c959d6993f554",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745925850,
+        "narHash": "sha256-cyAAMal0aPrlb1NgzMxZqeN1mAJ2pJseDhm2m6Um8T0=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "38bc60bbc157ae266d4a0c96671c6c742ee17a5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751296293,
+        "narHash": "sha256-oaGMVdCcI32y6jQ7RE0+CqshZngfI19XnY31eYjdinI=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "eaf37e2c98b66ff7f7a0ac04e4cada39e51fde4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,333 @@
+{
+  description = "Tower CLI and runtime environment for Tower with build targets and devShell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, fenix, naersk }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" "aarch64-linux" ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        rustToolchain = fenix.packages.${system}.stable.toolchain;
+        rustToolchainWithMusl = fenix.packages.${system}.stable.withComponents [
+          "cargo"
+          "rustc"
+          "rust-std"
+        ] // {
+          targets.x86_64-unknown-linux-musl = fenix.packages.${system}.targets.x86_64-unknown-linux-musl.stable.rust-std;
+        };
+
+        python = pkgs.python312;
+        naersk-native = naersk.lib.${system}.override {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
+
+        tower-cli = naersk-native.buildPackage {
+          src = ./.;
+          
+          cargoBuildOptions = x: x;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            openssl
+            zlib
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Tower CLI and runtime environment";
+            license = licenses.mit;
+            platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+            mainProgram = "tower";
+          };
+        };
+
+        mkCrossTarget = target: let
+          crossSystemConfig = {
+            "x86_64-unknown-linux-musl" = "x86_64-unknown-linux-musl";
+            "aarch64-unknown-linux-musl" = "aarch64-unknown-linux-musl";
+            "aarch64-apple-darwin" = "aarch64-apple-darwin";
+          }.${target};
+          
+          crossPkgs = import nixpkgs {
+            inherit system;
+            crossSystem = { config = crossSystemConfig; };
+          };
+
+          crossRustToolchain = fenix.packages.${system}.combine [
+            fenix.packages.${system}.stable.rustc
+            fenix.packages.${system}.stable.cargo
+            fenix.packages.${system}.targets.${target}.stable.rust-std
+          ];
+
+          naersk-cross = naersk.lib.${system}.override {
+            cargo = crossRustToolchain;
+            rustc = crossRustToolchain;
+          };
+
+        in naersk-cross.buildPackage {
+          src = ./.;
+          
+          cargoBuildOptions = x: x;
+
+          CARGO_BUILD_TARGET = target;
+          CARGO_BUILD_RUSTFLAGS = if (target == "x86_64-unknown-linux-musl" || target == "aarch64-unknown-linux-musl")
+            then "-C target-feature=+crt-static" 
+            else "";
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ] ++ pkgs.lib.optionals (target == "x86_64-unknown-linux-musl" || target == "aarch64-unknown-linux-musl") [
+            crossPkgs.stdenv.cc
+          ];
+
+          buildInputs = with crossPkgs; [
+            openssl
+            zlib
+          ];
+
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = 
+            if target == "x86_64-unknown-linux-musl" 
+            then "${crossPkgs.stdenv.cc.targetPrefix}cc"
+            else null;
+          
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = 
+            if target == "aarch64-unknown-linux-musl" 
+            then "${crossPkgs.stdenv.cc.targetPrefix}cc"
+            else null;
+
+          PKG_CONFIG_ALLOW_CROSS = "1";
+          OPENSSL_NO_VENDOR = "1";
+          OPENSSL_DIR = "${crossPkgs.openssl.dev}";
+          OPENSSL_LIB_DIR = "${crossPkgs.openssl.out}/lib";
+          OPENSSL_INCLUDE_DIR = "${crossPkgs.openssl.dev}/include";
+        };
+
+        tower-cli-linux-x86 = mkCrossTarget "x86_64-unknown-linux-musl";
+        tower-cli-linux-arm64 = mkCrossTarget "aarch64-unknown-linux-musl";
+        tower-cli-macos-arm = if system == "aarch64-darwin" then tower-cli else mkCrossTarget "aarch64-apple-darwin";
+
+      in {
+        packages = {
+          default = tower-cli;
+          tower-cli = tower-cli;
+          tower-cli-linux-x86 = tower-cli-linux-x86;
+          tower-cli-linux-arm64 = tower-cli-linux-arm64;
+          tower-cli-macos-arm = tower-cli-macos-arm;
+          
+          tower-cli-deb-x86 = pkgs.stdenv.mkDerivation {
+            name = "tower-cli-0.3.18-amd64.deb";
+            nativeBuildInputs = with pkgs; [ nfpm ];
+            
+            unpackPhase = "true";
+            
+            buildPhase = ''
+              mkdir -p package/usr/bin
+              cp ${tower-cli-linux-x86}/bin/tower package/usr/bin/
+              chmod 755 package/usr/bin/tower
+              
+              cat > nfpm.yaml << 'EOF'
+              name: tower-cli
+              arch: amd64
+              platform: linux
+              version: 0.3.18
+              section: utils
+              priority: optional
+              maintainer: Tower Computing Inc. <brad@tower.dev>
+              description: |
+                Tower CLI and runtime environment
+                Tower is the best way to host Python data apps in production.
+                This package provides the Tower CLI tool for managing and deploying
+                applications to the Tower platform.
+              vendor: Tower Computing Inc.
+              homepage: https://github.com/tower/tower-cli
+              license: MIT
+              
+              contents:
+                - src: package/usr/bin/tower
+                  dst: /usr/bin/tower
+                  file_info:
+                    mode: 0755
+              EOF
+            '';
+            
+            installPhase = ''
+              mkdir -p $out
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_0.3.18_amd64.deb
+            '';
+          };
+
+          tower-cli-deb-arm64 = pkgs.stdenv.mkDerivation {
+            name = "tower-cli-0.3.18-arm64.deb";
+            nativeBuildInputs = with pkgs; [ nfpm ];
+            
+            unpackPhase = "true";
+            
+            buildPhase = ''
+              mkdir -p package/usr/bin
+              cp ${tower-cli-linux-arm64}/bin/tower package/usr/bin/
+              chmod 755 package/usr/bin/tower
+              
+              cat > nfpm.yaml << 'EOF'
+              name: tower-cli
+              arch: arm64
+              platform: linux
+              version: 0.3.18
+              section: utils
+              priority: optional
+              maintainer: Tower Computing Inc. <brad@tower.dev>
+              description: |
+                Tower CLI and runtime environment
+                Tower is the best way to host Python data apps in production.
+                This package provides the Tower CLI tool for managing and deploying
+                applications to the Tower platform.
+              vendor: Tower Computing Inc.
+              homepage: https://github.com/tower/tower-cli
+              license: MIT
+              
+              contents:
+                - src: package/usr/bin/tower
+                  dst: /usr/bin/tower
+                  file_info:
+                    mode: 0755
+              EOF
+            '';
+            
+            installPhase = ''
+              mkdir -p $out
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_0.3.18_arm64.deb
+            '';
+          };
+          
+          tower-cli-rpm-x86 = pkgs.stdenv.mkDerivation {
+            name = "tower-cli-0.3.18-x86_64.rpm";
+            nativeBuildInputs = with pkgs; [ nfpm ];
+            
+            unpackPhase = "true";
+            
+            buildPhase = ''
+              mkdir -p package/usr/bin
+              cp ${tower-cli-linux-x86}/bin/tower package/usr/bin/
+              chmod 755 package/usr/bin/tower
+              
+              cat > nfpm.yaml << 'EOF'
+              name: tower-cli
+              arch: x86_64
+              platform: linux
+              version: 0.3.18
+              release: 1
+              maintainer: Tower Computing Inc. <brad@tower.dev>
+              description: |
+                Tower CLI and runtime environment
+                Tower is the best way to host Python data apps in production.
+                This package provides the Tower CLI tool for managing and deploying
+                applications to the Tower platform.
+              vendor: Tower Computing Inc.
+              homepage: https://github.com/tower/tower-cli
+              license: MIT
+              
+              contents:
+                - src: package/usr/bin/tower
+                  dst: /usr/bin/tower
+                  file_info:
+                    mode: 0755
+              EOF
+            '';
+            
+            installPhase = ''
+              mkdir -p $out
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-0.3.18-1.x86_64.rpm
+            '';
+          };
+
+          tower-cli-rpm-arm64 = pkgs.stdenv.mkDerivation {
+            name = "tower-cli-0.3.18-aarch64.rpm";
+            nativeBuildInputs = with pkgs; [ nfpm ];
+            
+            unpackPhase = "true";
+            
+            buildPhase = ''
+              mkdir -p package/usr/bin
+              cp ${tower-cli-linux-arm64}/bin/tower package/usr/bin/
+              chmod 755 package/usr/bin/tower
+              
+              cat > nfpm.yaml << 'EOF'
+              name: tower-cli
+              arch: aarch64
+              platform: linux
+              version: 0.3.18
+              release: 1
+              maintainer: Tower Computing Inc. <brad@tower.dev>
+              description: |
+                Tower CLI and runtime environment
+                Tower is the best way to host Python data apps in production.
+                This package provides the Tower CLI tool for managing and deploying
+                applications to the Tower platform.
+              vendor: Tower Computing Inc.
+              homepage: https://github.com/tower/tower-cli
+              license: MIT
+              
+              contents:
+                - src: package/usr/bin/tower
+                  dst: /usr/bin/tower
+                  file_info:
+                    mode: 0755
+              EOF
+            '';
+            
+            installPhase = ''
+              mkdir -p $out
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-0.3.18-1.aarch64.rpm
+            '';
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            rustToolchain
+            python
+            maturin
+            python312Packages.pip
+            pkg-config
+            openssl
+          ];
+          
+          buildInputs = with pkgs; [
+            openssl
+            zlib
+          ];
+
+          shellHook = ''
+            export RUST_LOG=debug
+            export PYTHONPATH=$PWD/src:$PYTHONPATH
+            echo "Tower CLI development environment"
+            echo "Python: $(python --version)"
+            echo "Rust: $(rustc --version)"
+          '';
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${tower-cli}/bin/tower";
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
           rustc = rustToolchain;
         };
 
-        tower-cli = naersk-native.buildPackage {
+        tower = naersk-native.buildPackage {
           src = ./.;
           
           cargoBuildOptions = x: x;
@@ -124,31 +124,31 @@
           OPENSSL_INCLUDE_DIR = "${crossPkgs.openssl.dev}/include";
         };
 
-        tower-cli-linux-x86 = mkCrossTarget "x86_64-unknown-linux-musl";
-        tower-cli-linux-arm64 = mkCrossTarget "aarch64-unknown-linux-musl";
-        tower-cli-macos-arm = if system == "aarch64-darwin" then tower-cli else mkCrossTarget "aarch64-apple-darwin";
+        tower-linux-x86 = mkCrossTarget "x86_64-unknown-linux-musl";
+        tower-linux-arm64 = mkCrossTarget "aarch64-unknown-linux-musl";
+        tower-macos-arm = if system == "aarch64-darwin" then tower else mkCrossTarget "aarch64-apple-darwin";
 
       in {
         packages = {
-          default = tower-cli;
-          tower-cli = tower-cli;
-          tower-cli-linux-x86 = tower-cli-linux-x86;
-          tower-cli-linux-arm64 = tower-cli-linux-arm64;
-          tower-cli-macos-arm = tower-cli-macos-arm;
+          default = tower;
+          tower = tower;
+          tower-linux-x86 = tower-linux-x86;
+          tower-linux-arm64 = tower-linux-arm64;
+          tower-macos-arm = tower-macos-arm;
           
-          tower-cli-deb-x86 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-${version}-amd64.deb";
+          tower-deb-x86 = pkgs.stdenv.mkDerivation {
+            name = "tower-${version}-amd64.deb";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
             
             buildPhase = ''
               mkdir -p package/usr/bin
-              cp ${tower-cli-linux-x86}/bin/tower package/usr/bin/
+              cp ${tower-linux-x86}/bin/tower package/usr/bin/
               chmod 755 package/usr/bin/tower
               
               cat > nfpm.yaml << 'EOF'
-              name: tower-cli
+              name: tower
               arch: amd64
               platform: linux
               version: ${version}
@@ -171,23 +171,23 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_${version}_amd64.deb
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower_${version}_amd64.deb
             '';
           };
 
           tower-cli-deb-arm64 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-${version}-arm64.deb";
+            name = "tower-${version}-arm64.deb";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
             
             buildPhase = ''
               mkdir -p package/usr/bin
-              cp ${tower-cli-linux-arm64}/bin/tower package/usr/bin/
+              cp ${tower-linux-arm64}/bin/tower package/usr/bin/
               chmod 755 package/usr/bin/tower
               
               cat > nfpm.yaml << 'EOF'
-              name: tower-cli
+              name: tower
               arch: arm64
               platform: linux
               version: ${version}
@@ -210,23 +210,23 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_${version}_arm64.deb
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower_${version}_arm64.deb
             '';
           };
           
-          tower-cli-rpm-x86 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-${version}-x86_64.rpm";
+          tower-rpm-x86 = pkgs.stdenv.mkDerivation {
+            name = "tower-${version}-x86_64.rpm";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
             
             buildPhase = ''
               mkdir -p package/usr/bin
-              cp ${tower-cli-linux-x86}/bin/tower package/usr/bin/
+              cp ${tower-linux-x86}/bin/tower package/usr/bin/
               chmod 755 package/usr/bin/tower
               
               cat > nfpm.yaml << 'EOF'
-              name: tower-cli
+              name: tower
               arch: x86_64
               platform: linux
               version: ${version}
@@ -248,23 +248,23 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-${version}-1.x86_64.rpm
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-${version}-1.x86_64.rpm
             '';
           };
 
-          tower-cli-rpm-arm64 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-${version}-aarch64.rpm";
+          tower-rpm-arm64 = pkgs.stdenv.mkDerivation {
+            name = "tower-${version}-aarch64.rpm";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
             
             buildPhase = ''
               mkdir -p package/usr/bin
-              cp ${tower-cli-linux-arm64}/bin/tower package/usr/bin/
+              cp ${tower-linux-arm64}/bin/tower package/usr/bin/
               chmod 755 package/usr/bin/tower
               
               cat > nfpm.yaml << 'EOF'
-              name: tower-cli
+              name: tower
               arch: aarch64
               platform: linux
               version: ${version}
@@ -286,7 +286,7 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-${version}-1.aarch64.rpm
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-${version}-1.aarch64.rpm
             '';
           };
         };
@@ -315,7 +315,7 @@
         apps = {
           default = {
             type = "app";
-            program = "${tower-cli}/bin/tower";
+            program = "${tower}/bin/tower";
           };
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           inherit system;
         };
 
-        version = "0.3.18";
+        version = builtins.readFile "${./.}/version.txt";
         maintainer = "Tower Computing Inc. <support@tower.dev>";
         homepage = "https://github.com/tower/tower-cli";
         description = "Tower CLI and runtime environment";

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,22 @@
           inherit system;
         };
 
+        version = "0.3.18";
+        maintainer = "Tower Computing Inc. <support@tower.dev>";
+        homepage = "https://github.com/tower/tower-cli";
+        description = "Tower CLI and runtime environment";
+        longDescription = ''
+          Tower CLI and runtime environment
+          Tower is the best way to host Python data apps in production.
+          This package provides the Tower CLI tool for managing and deploying
+          applications to the Tower platform.
+        '';
+
+        commonNativeBuildInputs = with pkgs; [ pkg-config ];
+        commonBuildInputs = with pkgs; [ openssl zlib ];
+
+        isMuslTarget = target: target == "x86_64-unknown-linux-musl" || target == "aarch64-unknown-linux-musl";
+
         rustToolchain = fenix.packages.${system}.stable.toolchain;
         rustToolchainWithMusl = fenix.packages.${system}.stable.withComponents [
           "cargo"
@@ -41,17 +57,11 @@
           
           cargoBuildOptions = x: x;
 
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-          ];
-
-          buildInputs = with pkgs; [
-            openssl
-            zlib
-          ];
+          nativeBuildInputs = commonNativeBuildInputs;
+          buildInputs = commonBuildInputs;
 
           meta = with pkgs.lib; {
-            description = "Tower CLI and runtime environment";
+            inherit description;
             license = licenses.mit;
             platforms = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
             mainProgram = "tower";
@@ -87,20 +97,15 @@
           cargoBuildOptions = x: x;
 
           CARGO_BUILD_TARGET = target;
-          CARGO_BUILD_RUSTFLAGS = if (target == "x86_64-unknown-linux-musl" || target == "aarch64-unknown-linux-musl")
+          CARGO_BUILD_RUSTFLAGS = if (isMuslTarget target)
             then "-C target-feature=+crt-static" 
             else "";
 
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-          ] ++ pkgs.lib.optionals (target == "x86_64-unknown-linux-musl" || target == "aarch64-unknown-linux-musl") [
+          nativeBuildInputs = commonNativeBuildInputs ++ pkgs.lib.optionals (isMuslTarget target) [
             crossPkgs.stdenv.cc
           ];
 
-          buildInputs = with crossPkgs; [
-            openssl
-            zlib
-          ];
+          buildInputs = with crossPkgs; commonBuildInputs;
 
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = 
             if target == "x86_64-unknown-linux-musl" 
@@ -132,7 +137,7 @@
           tower-cli-macos-arm = tower-cli-macos-arm;
           
           tower-cli-deb-x86 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-0.3.18-amd64.deb";
+            name = "tower-cli-${version}-amd64.deb";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
@@ -146,17 +151,14 @@
               name: tower-cli
               arch: amd64
               platform: linux
-              version: 0.3.18
+              version: ${version}
               section: utils
               priority: optional
-              maintainer: Tower Computing Inc. <brad@tower.dev>
+              maintainer: ${maintainer}
               description: |
-                Tower CLI and runtime environment
-                Tower is the best way to host Python data apps in production.
-                This package provides the Tower CLI tool for managing and deploying
-                applications to the Tower platform.
+                ${longDescription}
               vendor: Tower Computing Inc.
-              homepage: https://github.com/tower/tower-cli
+              homepage: ${homepage}
               license: MIT
               
               contents:
@@ -169,12 +171,12 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_0.3.18_amd64.deb
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_${version}_amd64.deb
             '';
           };
 
           tower-cli-deb-arm64 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-0.3.18-arm64.deb";
+            name = "tower-cli-${version}-arm64.deb";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
@@ -188,17 +190,14 @@
               name: tower-cli
               arch: arm64
               platform: linux
-              version: 0.3.18
+              version: ${version}
               section: utils
               priority: optional
-              maintainer: Tower Computing Inc. <brad@tower.dev>
+              maintainer: ${maintainer}
               description: |
-                Tower CLI and runtime environment
-                Tower is the best way to host Python data apps in production.
-                This package provides the Tower CLI tool for managing and deploying
-                applications to the Tower platform.
+                ${longDescription}
               vendor: Tower Computing Inc.
-              homepage: https://github.com/tower/tower-cli
+              homepage: ${homepage}
               license: MIT
               
               contents:
@@ -211,12 +210,12 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_0.3.18_arm64.deb
+              nfpm package --config nfpm.yaml --packager deb --target $out/tower-cli_${version}_arm64.deb
             '';
           };
           
           tower-cli-rpm-x86 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-0.3.18-x86_64.rpm";
+            name = "tower-cli-${version}-x86_64.rpm";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
@@ -230,16 +229,13 @@
               name: tower-cli
               arch: x86_64
               platform: linux
-              version: 0.3.18
+              version: ${version}
               release: 1
-              maintainer: Tower Computing Inc. <brad@tower.dev>
+              maintainer: ${maintainer}
               description: |
-                Tower CLI and runtime environment
-                Tower is the best way to host Python data apps in production.
-                This package provides the Tower CLI tool for managing and deploying
-                applications to the Tower platform.
+                ${longDescription}
               vendor: Tower Computing Inc.
-              homepage: https://github.com/tower/tower-cli
+              homepage: ${homepage}
               license: MIT
               
               contents:
@@ -252,12 +248,12 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-0.3.18-1.x86_64.rpm
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-${version}-1.x86_64.rpm
             '';
           };
 
           tower-cli-rpm-arm64 = pkgs.stdenv.mkDerivation {
-            name = "tower-cli-0.3.18-aarch64.rpm";
+            name = "tower-cli-${version}-aarch64.rpm";
             nativeBuildInputs = with pkgs; [ nfpm ];
             
             unpackPhase = "true";
@@ -271,16 +267,13 @@
               name: tower-cli
               arch: aarch64
               platform: linux
-              version: 0.3.18
+              version: ${version}
               release: 1
-              maintainer: Tower Computing Inc. <brad@tower.dev>
+              maintainer: ${maintainer}
               description: |
-                Tower CLI and runtime environment
-                Tower is the best way to host Python data apps in production.
-                This package provides the Tower CLI tool for managing and deploying
-                applications to the Tower platform.
+                ${longDescription}
               vendor: Tower Computing Inc.
-              homepage: https://github.com/tower/tower-cli
+              homepage: ${homepage}
               license: MIT
               
               contents:
@@ -293,7 +286,7 @@
             
             installPhase = ''
               mkdir -p $out
-              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-0.3.18-1.aarch64.rpm
+              nfpm package --config nfpm.yaml --packager rpm --target $out/tower-cli-${version}-1.aarch64.rpm
             '';
           };
         };
@@ -308,10 +301,7 @@
             openssl
           ];
           
-          buildInputs = with pkgs; [
-            openssl
-            zlib
-          ];
+          buildInputs = commonBuildInputs;
 
           shellHook = ''
             export RUST_LOG=debug


### PR DESCRIPTION
This PR introduces the ability to use this repo as a nix flake input for installing the tower repo. It also provides an ability to create basic `.deb` and `.rpm` packages using musl for static linking, but only because this was an incremental addition — this is not used anywhere yet. Additionally, binary caching is not set up anywhere, so it will need to build from scratch each time it's used. However, this shouldn't take too long, and the upside is that you can be guaranteed that you get the exact version in GitHub when fetched.

Try it out on this branch:
```
nix run github:tower/tower-cli/ben/add-nix-flake-support#tower -- login
```