### PR TITLE
Fix nix builds with nFPM

### DIFF
--- a/scripts/build-nix-target.sh
+++ b/scripts/build-nix-target.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")/.."
+
+VERSION=$(python scripts/semver.py)
+export VERSION
+
+TARGET=${1:-tower-deb-arm64}
+
+nix build .#${TARGET} --impure
+
+cp result/* ./ && rm result

--- a/scripts/semver.py
+++ b/scripts/semver.py
@@ -6,7 +6,7 @@ import argparse
 
 BASE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-SEMVER_EXP = re.compile("\d+\.\d+(\.\d+)?(-rc\.(\d+))?")
+SEMVER_EXP = re.compile(r"\d+\.\d+(\.\d+)?(-rc\.(\d+))?")
 
 class Version:
     def __init__(self, version_str):


### PR DESCRIPTION
Honestly this isn't very important, but I wanted to do this to test whether fNPM would successfully build a debian package on macOS re: a discussion I had with @konstantinoscs earlier today. I realize that we are using another system for linux/macOS builds, and this is not intended to replace that. It would however pave the way to distribute them as .rpm/.deb files in the future if we so wanted.