### PR TITLE
More refined dependency management for different app types

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -48,8 +48,6 @@ jobs:
         if: github.ref_name != 'main'
         run: >
           cargo test --all-features
-        env:
-          RUST_LOG: debug
 
       - run: bash .github/check-for-naughty-dependencies.sh
  

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,6 +2877,7 @@ version = "0.3.21-rc.1"
 dependencies = [
  "async-compression",
  "async_zip",
+ "dirs",
  "futures-lite",
  "reqwest",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,6 +2847,7 @@ name = "tower-runtime"
 version = "0.3.21-rc.1"
 dependencies = [
  "chrono",
+ "config",
  "snafu",
  "tokio",
  "tokio-util",

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -6,6 +6,8 @@ use tower_package::{Package, PackageSpec};
 use tower_runtime::{local::LocalApp, App, AppLauncher, OutputReceiver};
 use tower_telemetry::{Context, debug};
 
+use tokio::sync::mpsc::unbounded_channel;
+
 use crate::{
     output,
     api,
@@ -133,7 +135,7 @@ async fn do_run_local(config: Config, path: PathBuf, env: &str, mut params: Hash
         std::process::exit(1);
     }
 
-    let (sender, receiver) = tower_runtime::create_output_stream();
+    let (sender, receiver) = unbounded_channel();
 
     output::success(&format!("Launching app `{}`", towerfile.app.name));
     let output_task = tokio::spawn(monitor_output(receiver));

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -342,9 +342,9 @@ async fn build_package(towerfile: &Towerfile) -> Package {
 
 /// monitor_output is a helper function that will monitor the output of a given output channel and
 /// plops it down on stdout.
-async fn monitor_output(output: OutputReceiver) {
+async fn monitor_output(mut output: OutputReceiver) {
     loop {
-        if let Some(line) = output.lock().await.recv().await {
+        if let Some(line) = output.recv().await {
             let ts = &line.time;
             let msg = &line.line;
             output::log_line(&ts.to_rfc3339(), msg, output::LogLineType::Local);

--- a/crates/tower-runtime/Cargo.toml
+++ b/crates/tower-runtime/Cargo.toml
@@ -14,3 +14,6 @@ snafu = { workspace = true }
 tower-package = { workspace = true } 
 tower-telemetry = { workspace = true } 
 tower-uv = { workspace = true } 
+
+[dev-dependencies]
+config = { workspace = true }

--- a/crates/tower-runtime/src/errors.rs
+++ b/crates/tower-runtime/src/errors.rs
@@ -85,6 +85,7 @@ impl From<tower_uv::Error> for Error {
            tower_uv::Error::NotFound(_) => Error::SpawnFailed, 
            tower_uv::Error::PermissionDenied(_) => Error::SpawnFailed, 
            tower_uv::Error::Other(_) => Error::SpawnFailed, 
+           tower_uv::Error::MissingPyprojectToml => Error::SpawnFailed, 
         }
     }
 }

--- a/crates/tower-runtime/src/errors.rs
+++ b/crates/tower-runtime/src/errors.rs
@@ -86,6 +86,8 @@ impl From<tower_uv::Error> for Error {
            tower_uv::Error::PermissionDenied(_) => Error::SpawnFailed, 
            tower_uv::Error::Other(_) => Error::SpawnFailed, 
            tower_uv::Error::MissingPyprojectToml => Error::SpawnFailed, 
+           tower_uv::Error::InvalidUv => Error::SpawnFailed, 
+           tower_uv::Error::UnsupportedPlatform => Error::UnsupportedPlatform,
         }
     }
 }

--- a/crates/tower-runtime/src/lib.rs
+++ b/crates/tower-runtime/src/lib.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use tokio::sync::mpsc::{
     UnboundedReceiver,
     UnboundedSender,
-    unbounded_channel,
 };
 use chrono::{DateTime, Utc};
 
@@ -73,11 +72,6 @@ impl<A: App> std::default::Default for AppLauncher<A> {
             app: None,
         }
     }
-}
-
-pub fn create_output_stream() -> (OutputSender, OutputReceiver) {
-    let (sender, receiver) = unbounded_channel::<Output>();
-    (sender, receiver)
 }
 
 impl<A: App> AppLauncher<A> {

--- a/crates/tower-runtime/src/lib.rs
+++ b/crates/tower-runtime/src/lib.rs
@@ -41,7 +41,7 @@ pub struct Output {
     pub line: String,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Status {
     None,
     Running,

--- a/crates/tower-runtime/src/lib.rs
+++ b/crates/tower-runtime/src/lib.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 use std::future::Future;
-use std::sync::Arc;
 use std::collections::HashMap;
-use tokio::sync::Mutex;
 use tokio::sync::mpsc::{
     UnboundedReceiver,
     UnboundedSender,

--- a/crates/tower-runtime/tests/example-apps/01-hello-world/Towerfile
+++ b/crates/tower-runtime/tests/example-apps/01-hello-world/Towerfile
@@ -1,0 +1,3 @@
+[app]
+name = "01-hello-world"
+script = "./task.py"

--- a/crates/tower-runtime/tests/example-apps/01-hello-world/task.py
+++ b/crates/tower-runtime/tests/example-apps/01-hello-world/task.py
@@ -1,0 +1,2 @@
+for i in range(0, 5):
+    print("Hello, world!")

--- a/crates/tower-runtime/tests/example-apps/02-use-faker/Towerfile
+++ b/crates/tower-runtime/tests/example-apps/02-use-faker/Towerfile
@@ -1,0 +1,3 @@
+[app]
+name = "02-use-faker"
+script = "./main.py"

--- a/crates/tower-runtime/tests/example-apps/02-use-faker/main.py
+++ b/crates/tower-runtime/tests/example-apps/02-use-faker/main.py
@@ -1,0 +1,9 @@
+from faker import Faker
+
+def main():
+    fake = Faker()
+    print(fake.name())
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/tower-runtime/tests/example-apps/02-use-faker/pyproject.toml
+++ b/crates/tower-runtime/tests/example-apps/02-use-faker/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "02-get-current-ip"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "faker>=37.4.2",
+]

--- a/crates/tower-runtime/tests/example-apps/02-use-faker/uv.lock
+++ b/crates/tower-runtime/tests/example-apps/02-use-faker/uv.lock
@@ -1,0 +1,35 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "02-get-current-ip"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "faker" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "faker", specifier = ">=37.4.2" }]
+
+[[package]]
+name = "faker"
+version = "37.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/da573e055608e180086e2ac3208f8c15d8b44220912f565a9821b9bff33a/faker-37.4.2.tar.gz", hash = "sha256:8e281bbaea30e5658895b8bea21cc50d27aaf3a43db3f2694409ca5701c56b0a", size = 1902890, upload-time = "2025-07-15T16:38:24.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/1c/b909a055be556c11f13cf058cfa0e152f9754d803ff3694a937efe300709/faker-37.4.2-py3-none-any.whl", hash = "sha256:b70ed1af57bfe988cbcd0afd95f4768c51eaf4e1ce8a30962e127ac5c139c93f", size = 1943179, upload-time = "2025-07-15T16:38:23.053Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]

--- a/crates/tower-runtime/tests/example-apps/03-legacy-app/Towerfile
+++ b/crates/tower-runtime/tests/example-apps/03-legacy-app/Towerfile
@@ -1,0 +1,3 @@
+[app]
+name = "03-legacy-app"
+script = "task.py"

--- a/crates/tower-runtime/tests/example-apps/03-legacy-app/requirements.txt
+++ b/crates/tower-runtime/tests/example-apps/03-legacy-app/requirements.txt
@@ -1,0 +1,2 @@
+dlt[snowflake,filesystem]==1.4.0
+pandas

--- a/crates/tower-runtime/tests/example-apps/03-legacy-app/task.py
+++ b/crates/tower-runtime/tests/example-apps/03-legacy-app/task.py
@@ -1,0 +1,2 @@
+import dlt
+print(dlt.version.__version__)

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -35,7 +35,7 @@ async fn build_package_from_dir(dir: &PathBuf) -> Package {
     package
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_running_hello_world() {
     tower_telemetry::enable_logging(
         tower_telemetry::LogLevel::Debug,
@@ -77,7 +77,7 @@ async fn test_running_hello_world() {
     assert!(status == Status::Exited, "App should be running");
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn test_running_use_faker() {
     debug!("Running 02-use-faker");
     // This test is a simple test that outputs some text to the console; however, this time it has

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -35,7 +35,7 @@ async fn build_package_from_dir(dir: &PathBuf) -> Package {
     package
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn test_running_hello_world() {
     tower_telemetry::enable_logging(
         tower_telemetry::LogLevel::Debug,
@@ -68,6 +68,7 @@ async fn test_running_hello_world() {
     assert!(status == Status::Running, "App should be running");
 
     while let Some(output) = receiver.recv().await {
+        debug!("Received output: {:?}", output.line);
         assert!(output.line.contains("Hello, world!"), "Log should contain 'Hello, world!'");
     }
 
@@ -76,7 +77,7 @@ async fn test_running_hello_world() {
     assert!(status == Status::Exited, "App should be running");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn test_running_use_faker() {
     debug!("Running 02-use-faker");
     // This test is a simple test that outputs some text to the console; however, this time it has
@@ -108,6 +109,7 @@ async fn test_running_use_faker() {
     let mut count_stdout = 0;
 
     while let Some(output) = receiver.recv().await {
+        debug!("Received output: {:?}", output.line);
         match output.channel {
             tower_runtime::Channel::Setup => {
                 count_setup += 1;

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -74,7 +74,7 @@ async fn test_running_hello_world() {
 #[tokio::test]
 async fn test_running_use_faker() {
     // This test is a simple test that outputs some text to the console; however, this time it has
-    // a depedency defined in pyprojec.toml, which means that it'll have to do a uv sync first.
+    // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
     let use_faker_dir = get_example_app_dir("02-use-faker");
     let package = build_package_from_dir(&use_faker_dir).await;
     let (sender, receiver) = create_output_stream();

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tower_runtime::{
+    App,
+    StartOptions,
+    Status,
+    create_output_stream,
+    local::LocalApp,
+};
+
+use config::Towerfile;
+use tower_package::{Package, PackageSpec};
+
+fn get_example_app_dir(name: &str) -> PathBuf {
+    // This is where the root of the app lives.
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests");
+    path.push("example-apps");
+    path.push(name);
+
+    if !path.exists() {
+        panic!("Example app directory does not exist: {}", path.display());
+    }
+
+    path
+}
+
+async fn build_package_from_dir(dir: &PathBuf) -> Package {
+    let towerfile = Towerfile::from_path(dir.join("Towerfile")).expect("Failed to load Towerfile"); 
+    let spec = PackageSpec::from_towerfile(&towerfile);
+    let mut package = Package::build(spec).await.expect("Failed to build package from directory");
+    package.unpack().await.expect("Failed to unpack package");
+    package
+}
+
+#[tokio::test]
+async fn test_running_hello_world() {
+    let hello_world_dir = get_example_app_dir("01-hello-world");
+    let package = build_package_from_dir(&hello_world_dir).await;
+    let (sender, receiver) = create_output_stream();
+
+    // We need to create the package, which will load the app
+    let opts = StartOptions{
+        ctx: tower_telemetry::Context::new(),
+        package,
+        output_sender: Some(sender),
+        cwd: None,
+        environment: "local".to_string(),
+        secrets: HashMap::new(),
+        parameters: HashMap::new(),
+        env_vars: HashMap::new(),
+    };
+
+    // Start the app using the LocalApp runtime
+    let app = LocalApp::start(opts).await.expect("Failed to start app");
+
+    // The status should be running
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Running, "App should be running");
+
+    // Now we should wait for the output
+    let mut receiver = receiver.lock().await;
+
+    while let Some(output) = receiver.recv().await {
+        assert!(output.line.contains("Hello, world!"), "Log should contain 'Hello, world!'");
+    }
+
+    // check the status once more, should be done.
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Exited, "App should be running");
+}
+
+#[tokio::test]
+async fn test_running_use_faker() {
+    // This test is a simple test that outputs some text to the console; however, this time it has
+    // a depedency defined in pyprojec.toml, which means that it'll have to do a uv sync first.
+    let use_faker_dir = get_example_app_dir("02-use-faker");
+    let package = build_package_from_dir(&use_faker_dir).await;
+    let (sender, receiver) = create_output_stream();
+
+    // We need to create the package, which will load the app
+    let opts = StartOptions{
+        ctx: tower_telemetry::Context::new(),
+        package,
+        output_sender: Some(sender),
+        cwd: None,
+        environment: "local".to_string(),
+        secrets: HashMap::new(),
+        parameters: HashMap::new(),
+        env_vars: HashMap::new(),
+    };
+
+    // Start the app using the LocalApp runtime
+    let app = LocalApp::start(opts).await.expect("Failed to start app");
+
+    // The status should be running
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Running, "App should be running");
+
+    // Now we should wait for the output
+    let mut receiver = receiver.lock().await;
+
+    let mut count_setup = 0;
+    let mut count_stdout = 0;
+
+    while let Some(output) = receiver.recv().await {
+        match output.channel {
+            tower_runtime::Channel::Setup => {
+                count_setup += 1;
+            },
+            tower_runtime::Channel::Program => {
+                count_stdout += 1;
+            }
+        }
+    }
+
+    assert!(count_setup > 0, "There should be some setup output");
+    assert!(count_stdout == 1, "There should be exactly one stdout output");
+
+    // check the status once more, should be done.
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Exited, "App should be running");
+}

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -11,6 +11,7 @@ use tower_runtime::{
 
 use config::Towerfile;
 use tower_package::{Package, PackageSpec};
+use tower_telemetry::{self, debug};
 
 fn get_example_app_dir(name: &str) -> PathBuf {
     // This is where the root of the app lives.
@@ -36,6 +37,13 @@ async fn build_package_from_dir(dir: &PathBuf) -> Package {
 
 #[tokio::test]
 async fn test_running_hello_world() {
+    tower_telemetry::enable_logging(
+        tower_telemetry::LogLevel::Debug,
+        tower_telemetry::LogFormat::Plain,
+        tower_telemetry::LogDestination::Stdout,
+    );
+
+    debug!("Running 01-hello-world");
     let hello_world_dir = get_example_app_dir("01-hello-world");
     let package = build_package_from_dir(&hello_world_dir).await;
     let (sender, mut receiver) = create_output_stream();
@@ -70,6 +78,7 @@ async fn test_running_hello_world() {
 
 #[tokio::test]
 async fn test_running_use_faker() {
+    debug!("Running 02-use-faker");
     // This test is a simple test that outputs some text to the console; however, this time it has
     // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
     let use_faker_dir = get_example_app_dir("02-use-faker");

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -121,7 +121,7 @@ async fn test_running_use_faker() {
     }
 
     assert!(count_setup > 0, "There should be some setup output");
-    assert!(count_stdout == 1, "There should be exactly one stdout output");
+    assert!(count_stdout > 0, "should be more than one output");
 
     // check the status once more, should be done.
     let status = app.status().await.expect("Failed to get app status");

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -68,8 +68,12 @@ async fn test_running_hello_world() {
     assert!(status == Status::Running, "App should be running");
 
     while let Some(output) = receiver.recv().await {
-        debug!("Received output: {:?}", output.line);
-        assert!(output.line.contains("Hello, world!"), "Log should contain 'Hello, world!'");
+        let valid_line = output.line.contains("Hello, world!") || 
+                         output.line.contains("Using CPython") ||
+                         output.line.contains("Creating virtual environment") ||
+                         output.line.contains("Activate with");
+
+        assert!(valid_line, "Log should contain 'Hello, world!' or a setup line");
     }
 
     // check the status once more, should be done.
@@ -84,6 +88,57 @@ async fn test_running_use_faker() {
     // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
     let use_faker_dir = get_example_app_dir("02-use-faker");
     let package = build_package_from_dir(&use_faker_dir).await;
+    let (sender, mut receiver) = create_output_stream();
+
+    // We need to create the package, which will load the app
+    let opts = StartOptions{
+        ctx: tower_telemetry::Context::new(),
+        package,
+        output_sender: sender,
+        cwd: None,
+        environment: "local".to_string(),
+        secrets: HashMap::new(),
+        parameters: HashMap::new(),
+        env_vars: HashMap::new(),
+    };
+
+    // Start the app using the LocalApp runtime
+    let app = LocalApp::start(opts).await.expect("Failed to start app");
+
+    // The status should be running
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Running, "App should be running");
+
+    let mut count_setup = 0;
+    let mut count_stdout = 0;
+
+    while let Some(output) = receiver.recv().await {
+        debug!("Received output: {:?}", output.line);
+        match output.channel {
+            tower_runtime::Channel::Setup => {
+                count_setup += 1;
+            },
+            tower_runtime::Channel::Program => {
+                count_stdout += 1;
+            }
+        }
+    }
+
+    assert!(count_setup > 0, "There should be some setup output");
+    assert!(count_stdout > 0, "should be more than one output");
+
+    // check the status once more, should be done.
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(status == Status::Exited, "App should be running");
+}
+
+#[tokio::test]
+async fn test_running_legacy_app() {
+    debug!("Running 03-legacy-app");
+    // This test is a simple test that outputs some text to the console; however, this time it has
+    // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
+    let legacy_app_dir = get_example_app_dir("03-legacy-app");
+    let package = build_package_from_dir(&legacy_app_dir).await;
     let (sender, mut receiver) = create_output_stream();
 
     // We need to create the package, which will load the app

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -5,13 +5,14 @@ use tower_runtime::{
     App,
     StartOptions,
     Status,
-    create_output_stream,
     local::LocalApp,
 };
 
 use config::Towerfile;
 use tower_package::{Package, PackageSpec};
 use tower_telemetry::{self, debug};
+
+use tokio::sync::mpsc::unbounded_channel;
 
 fn get_example_app_dir(name: &str) -> PathBuf {
     // This is where the root of the app lives.
@@ -46,7 +47,7 @@ async fn test_running_hello_world() {
     debug!("Running 01-hello-world");
     let hello_world_dir = get_example_app_dir("01-hello-world");
     let package = build_package_from_dir(&hello_world_dir).await;
-    let (sender, mut receiver) = create_output_stream();
+    let (sender, mut receiver) = unbounded_channel();
 
     // We need to create the package, which will load the app
     let opts = StartOptions{
@@ -88,7 +89,7 @@ async fn test_running_use_faker() {
     // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
     let use_faker_dir = get_example_app_dir("02-use-faker");
     let package = build_package_from_dir(&use_faker_dir).await;
-    let (sender, mut receiver) = create_output_stream();
+    let (sender, mut receiver) = unbounded_channel();
 
     // We need to create the package, which will load the app
     let opts = StartOptions{
@@ -139,7 +140,7 @@ async fn test_running_legacy_app() {
     // a dependency defined in pyproject.toml, which means that it'll have to do a uv sync first.
     let legacy_app_dir = get_example_app_dir("03-legacy-app");
     let package = build_package_from_dir(&legacy_app_dir).await;
-    let (sender, mut receiver) = create_output_stream();
+    let (sender, mut receiver) = unbounded_channel();
 
     // We need to create the package, which will load the app
     let opts = StartOptions{

--- a/crates/tower-uv/Cargo.toml
+++ b/crates/tower-uv/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 [dependencies]
 async-compression = { workspace = true }
 async_zip = { workspace = true }
+dirs = { workspace = true }
 futures-lite = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }

--- a/crates/tower-uv/src/install.rs
+++ b/crates/tower-uv/src/install.rs
@@ -337,10 +337,11 @@ async fn find_uv_binary() -> Option<PathBuf> {
 
 pub async fn find_or_setup_uv() -> Result<PathBuf, Error> {
     // We only allow setup in the process space at a given time.
-    let _ = get_global_lock().lock().await;
+    let _guard = get_global_lock().lock().await;
 
     // If we get here, uv wasn't found in PATH, so let's download it
     if let Some(path) = find_uv_binary().await {
+        debug!("UV binary found at {:?}", path);
         Ok(path) 
     } else {
         let path = get_default_uv_bin_dir()?;

--- a/crates/tower-uv/src/install.rs
+++ b/crates/tower-uv/src/install.rs
@@ -1,8 +1,12 @@
 use std::env;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use tokio_tar::Archive;
-use tokio::process::Command;
+use tokio::{
+    sync::Mutex,
+    process::Command,
+};
 use async_compression::tokio::bufread::GzipDecoder;
 use async_zip::tokio::read::seek::ZipFileReader;
 use futures_lite::io::AsyncReadExt;
@@ -12,8 +16,15 @@ use tower_telemetry::debug;
 // Copy the UV_VERSION locally to make this a bit more ergonomic.
 const UV_VERSION: &str = crate::UV_VERSION;
 
+static GLOBAL_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn get_global_lock() -> &'static Mutex<()> {
+    GLOBAL_LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[derive(Debug)]
 pub enum Error {
+    NotFound(String),
     UnsupportedPlatform,
     IoError(std::io::Error),
     Other(String),
@@ -308,4 +319,60 @@ pub async fn download_uv_for_arch(path: &PathBuf) -> Result<PathBuf, Error> {
     let path = download_uv_archive(path, archive).await?;
     debug!("Downloaded UV to: {:?}", path);
     Ok(path)
+}
+
+async fn find_uv_binary() -> Option<PathBuf> {
+    if let Ok(default_path) = get_default_uv_bin_dir() {
+        // Check if the default path exists
+        if default_path.exists() {
+            let uv_path = default_path.join("uv");
+            if uv_path.exists() {
+                return Some(uv_path);
+            }
+        } 
+    }
+    
+    None
+} 
+
+pub async fn find_or_setup_uv() -> Result<PathBuf, Error> {
+    // We only allow setup in the process space at a given time.
+    let _ = get_global_lock().lock().await;
+
+    // If we get here, uv wasn't found in PATH, so let's download it
+    if let Some(path) = find_uv_binary().await {
+        Ok(path) 
+    } else {
+        let path = get_default_uv_bin_dir()?;
+        debug!("UV binary not found in PATH, setting up UV at {:?}", path);
+
+        // Create the directory if it doesn't exist
+        std::fs::create_dir_all(&path).map_err(Error::IoError)?;
+
+        let parent = path.parent()
+            .ok_or_else(|| Error::NotFound("Parent directory not found".to_string()))?
+            .to_path_buf();
+
+        // We download this code to the UV directory
+        let exe = download_uv_for_arch(&parent).await?;
+
+        // Target is the UV binary we want.
+        let target = path.join("uv");
+
+        // Copy the `uv` binary into the default directory
+        tokio::fs::copy(&exe, &target)
+            .await?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&target)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&target, perms)?;
+        }
+
+        debug!("Copied UV binary from {:?} to {:?}", exe, target);
+
+        Ok(target)
+    }
 }

--- a/crates/tower-uv/src/install.rs
+++ b/crates/tower-uv/src/install.rs
@@ -14,6 +14,7 @@ const UV_VERSION: &str = crate::UV_VERSION;
 
 #[derive(Debug)]
 pub enum Error {
+    UnsupportedPlatform,
     IoError(std::io::Error),
     Other(String),
 }
@@ -31,7 +32,8 @@ impl From<String> for Error {
 }
 
 pub fn get_default_uv_bin_dir() -> Result<PathBuf, Error> {
-    Ok(PathBuf::from(".tower/bin"))
+    let dir = dirs::data_local_dir().ok_or(Error::UnsupportedPlatform)?;
+    Ok(dir.join("tower").join("bin"))
 }
 
 #[derive(Debug)]

--- a/crates/tower-uv/src/install.rs
+++ b/crates/tower-uv/src/install.rs
@@ -303,6 +303,7 @@ async fn download_uv_archive(path: &PathBuf, archive: String) -> Result<PathBuf,
 }
 
 pub async fn download_uv_for_arch(path: &PathBuf) -> Result<PathBuf, Error> {
+    debug!("Starting download of UV for current architecture");
     let archive = ArchiveSelector::get_archive_name().await?;
     let path = download_uv_archive(path, archive).await?;
     debug!("Downloaded UV to: {:?}", path);

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -15,6 +15,7 @@ pub enum Error {
     NotFound(String),
     PermissionDenied(String),
     Other(String),
+    MissingPyprojectToml,
 }
 
 impl From<std::io::Error> for Error {
@@ -120,6 +121,12 @@ impl Uv {
     }
 
     pub async fn sync(&self, cwd: &PathBuf, env_vars: &HashMap<String, String>) -> Result<Child, Error> {
+        // Make sure there's a pyproject.toml in the cwd. If there isn't wont, then we don't want
+        // to do this otherwise uv will return an error on the CLI!
+        if !cwd.join("pyproject.toml").exists() {
+            return Err(Error::MissingPyprojectToml);
+        } 
+
         debug!("Executing UV ({:?}) sync in {:?}", &self.uv_path, cwd);
 
         let child = Command::new(&self.uv_path)

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -147,9 +147,6 @@ impl Uv {
     }
 
     pub async fn is_valid(&self) -> bool {
-        match test_uv_path(&self.uv_path).await {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        test_uv_path(&self.uv_path).await.is_ok()
     }
 }

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -121,7 +121,7 @@ impl Uv {
     }
 
     pub async fn sync(&self, cwd: &PathBuf, env_vars: &HashMap<String, String>) -> Result<Child, Error> {
-        // Make sure there's a pyproject.toml in the cwd. If there isn't wont, then we don't want
+        // Make sure there's a pyproject.toml in the cwd. If there isn't one, then we don't want
         // to do this otherwise uv will return an error on the CLI!
         if !cwd.join("pyproject.toml").exists() {
             return Err(Error::MissingPyprojectToml);

--- a/crates/tower-uv/tests/install_test.rs
+++ b/crates/tower-uv/tests/install_test.rs
@@ -9,7 +9,7 @@ async fn test_installing_uv() {
     let default_uv_bin_dir = get_default_uv_bin_dir().unwrap();
     let _ = tokio::fs::remove_dir_all(&default_uv_bin_dir).await;
 
-    // Now if we instantiate a Uv instance, it should install the `uv` bianry.
+    // Now if we instantiate a Uv instance, it should install the `uv` binary.
     let uv = Uv::new().await.expect("Failed to create a Uv instance");
     assert!(uv.is_valid().await);
 }

--- a/crates/tower-uv/tests/install_test.rs
+++ b/crates/tower-uv/tests/install_test.rs
@@ -1,0 +1,15 @@
+use tower_uv::{
+    install::get_default_uv_bin_dir,
+    Uv,
+};
+
+#[tokio::test]
+async fn test_installing_uv() {
+    // Ensure there is no `uv` in the directory that we will install it to by default.
+    let default_uv_bin_dir = get_default_uv_bin_dir().unwrap();
+    let _ = tokio::fs::remove_dir_all(&default_uv_bin_dir).await;
+
+    // Now if we instantiate a Uv instance, it should install the `uv` bianry.
+    let uv = Uv::new().await.expect("Failed to create a Uv instance");
+    assert!(uv.is_valid().await);
+}


### PR DESCRIPTION
This PR does a few different things.

1. Always setup a virtual environment for every app.
2. If the user is using requirements.txt (our legacy suggestion), then manage dependencies using that.
3. If the user is using pyproject.toml, use `uv sync` for setup.
4. If the user is using neither, do nothing.

It also adds some test coverage for running different types of apps via `tower-runtime` to ensure the behavior doesn't change over time.