### PR TITLE
Add integrity checks during package upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "glob",
  "serde",
  "serde_json",
+ "sha2",
  "snafu",
  "tmpdir",
  "tokio",

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
-use tower_package::Package;
+use tower_package::{Package, compute_sha256_file};
 use tower_telemetry::debug;
 
 use tower_api::apis::configuration::Configuration;
@@ -17,10 +17,17 @@ pub async fn upload_file_with_progress(
     api_config: &Configuration,
     endpoint_url: String,
     file_path: PathBuf,
-    package_hash: &str,
     content_type: &str,
     progress_cb: Box<dyn Fn(u64, u64) + Send + Sync>,
 ) -> Result<DeployAppResponse, Error<DeployAppError>> {
+    let package_hash = match compute_sha256_file(&file_path).await {
+        Ok(hash) => hash,
+        Err(e) => {
+            debug!("Failed to compute package hash: {}", e);
+            output::die("Tower CLI failed to properly prepare your package for deployment. Check that you have permissions to read/write to your temporary directory, and if it keeps happening contact Tower support at https://tower.dev");
+        }
+    };
+
     // Get the file and its metadata
     let file = File::open(file_path).await?;
     let metadata = file.metadata().await?;
@@ -35,7 +42,7 @@ pub async fn upload_file_with_progress(
     let client = ReqwestClient::new();
     let mut req = client
         .request(Method::POST, endpoint_url)
-        .header("X-Tower-Package-Hash", package_hash)
+        .header("X-Tower-Checksum-SHA256", package_hash)
         .header("Content-Type", content_type)
         .header("Content-Encoding", "gzip")
         .body(Body::wrap_stream(progress_stream));
@@ -93,10 +100,6 @@ pub async fn deploy_app_package(
         output::die("An error happened in Tower CLI that it couldn't recover from.");
     });
 
-    let package_hash = package.package_file_hash.unwrap_or_else(|| {
-        "".to_string()
-    });
-
     // Create the URL for the API endpoint
     let base_url = &api_config.base_path;
     let url = format!("{}/apps/{}/deploy", base_url, app_name);
@@ -106,7 +109,6 @@ pub async fn deploy_app_package(
         api_config,
         url,
         package_path,
-        &package_hash,
         "application/tar",
         progress_callback,
     )

--- a/crates/tower-cmd/src/util/progress.rs
+++ b/crates/tower-cmd/src/util/progress.rs
@@ -5,8 +5,12 @@ use std::{
     task::{Context, Poll},
 };
 
+use std::fs::File;
+use std::io::Write;
+
 pub struct ProgressStream<R> {
     inner: R,
+    file: Arc<Mutex<File>>,
     progress: Arc<Mutex<u64>>,
     progress_cb: Box<dyn Fn(u64, u64) + Send + Sync>,
     total_size: u64,
@@ -18,7 +22,10 @@ impl<R> ProgressStream<R> {
         total_size: u64,
         progress_cb: Box<dyn Fn(u64, u64) + Send + Sync>,
     ) -> Result<Self, std::io::Error> {
+        let file = File::create("/tmp/input.dat").expect("Failed to create file");
+
         Ok(Self {
+            file: Arc::new(Mutex::new(file)),
             inner,
             progress_cb,
             progress: Arc::new(Mutex::new(0)),
@@ -37,6 +44,10 @@ impl<R: Stream<Item = Result<bytes::Bytes, std::io::Error>> + Unpin> Stream for 
                 let mut progress = self.progress.lock().unwrap();
                 *progress += chunk_size;
                 (self.progress_cb)(*progress, self.total_size);
+
+                let mut file = self.file.lock().expect("Lock couldn't be acquired");
+                file.write(&chunk).expect("Failed to write to file");
+
                 Poll::Ready(Some(Ok(chunk)))
             }
             other => other,

--- a/crates/tower-cmd/src/util/progress.rs
+++ b/crates/tower-cmd/src/util/progress.rs
@@ -5,12 +5,8 @@ use std::{
     task::{Context, Poll},
 };
 
-use std::fs::File;
-use std::io::Write;
-
 pub struct ProgressStream<R> {
     inner: R,
-    file: Arc<Mutex<File>>,
     progress: Arc<Mutex<u64>>,
     progress_cb: Box<dyn Fn(u64, u64) + Send + Sync>,
     total_size: u64,
@@ -22,10 +18,7 @@ impl<R> ProgressStream<R> {
         total_size: u64,
         progress_cb: Box<dyn Fn(u64, u64) + Send + Sync>,
     ) -> Result<Self, std::io::Error> {
-        let file = File::create("/tmp/input.dat").expect("Failed to create file");
-
         Ok(Self {
-            file: Arc::new(Mutex::new(file)),
             inner,
             progress_cb,
             progress: Arc::new(Mutex::new(0)),
@@ -42,11 +35,9 @@ impl<R: Stream<Item = Result<bytes::Bytes, std::io::Error>> + Unpin> Stream for 
             Poll::Ready(Some(Ok(chunk))) => {
                 let chunk_size = chunk.len() as u64;
                 let mut progress = self.progress.lock().unwrap();
+
                 *progress += chunk_size;
                 (self.progress_cb)(*progress, self.total_size);
-
-                let mut file = self.file.lock().expect("Lock couldn't be acquired");
-                file.write(&chunk).expect("Failed to write to file");
 
                 Poll::Ready(Some(Ok(chunk)))
             }

--- a/crates/tower-package/Cargo.toml
+++ b/crates/tower-package/Cargo.toml
@@ -12,6 +12,7 @@ config = { workspace = true }
 glob = { workspace = true }
 serde = { workspace = true } 
 serde_json = { workspace = true } 
+sha2 = { workspace = true }
 snafu = { workspace = true } 
 tmpdir = { workspace = true }
 tokio = { workspace = true } 

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -285,7 +285,7 @@ impl Package {
            schedule: spec.schedule,
            app_dir_name: app_dir.to_string_lossy().to_string(),
            modules_dir_name: module_dir.to_string_lossy().to_string(),
-           checksum: compute_sha256_package(&path_hashes).await?,
+           checksum: compute_sha256_package(&path_hashes)?,
        };
 
        // the whole manifest needs to be written to a file as a convenient way to avoid having to
@@ -510,7 +510,7 @@ fn should_ignore_file(p: &PathBuf) -> bool {
     return false;
 }
 
-async fn compute_sha256_package(path_hashes: &HashMap<PathBuf, String>) -> Result<String, Error> {
+fn compute_sha256_package(path_hashes: &HashMap<PathBuf, String>) -> Result<String, Error> {
     let mut sorted_keys: Vec<&PathBuf> = path_hashes.keys().collect();
     sorted_keys.sort();
 
@@ -520,7 +520,9 @@ async fn compute_sha256_package(path_hashes: &HashMap<PathBuf, String>) -> Resul
     for key in sorted_keys {
         // We need to sort the keys so that we can compute a consistent hash.
         let value = path_hashes.get(key).unwrap();
-        hasher.update(value.as_bytes());
+
+        let combined = format!("{}:{}", key.display(), value);
+        hasher.update(combined.as_bytes());
     }
     
     // Finalize and get the hash result

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -154,6 +154,10 @@ pub struct Package {
 
     // unpacked_path is the path to the unpackaged package on disk.
     pub unpacked_path: Option<PathBuf>,
+
+    // package_file_hash is an integrity hash of the package file.
+    pub package_file_hash: Option<String>,
+
 }
 
 impl Package {
@@ -161,6 +165,7 @@ impl Package {
        Self {
            tmp_dir: None,
            package_file_path: None,
+           package_file_hash: None,
            unpacked_path: None,
            manifest: Manifest {
                version: Some(CURRENT_PACKAGE_VERSION),
@@ -182,6 +187,7 @@ impl Package {
        Self {
            tmp_dir: None,
            package_file_path: None,
+           package_file_hash: None,
            unpacked_path: Some(path),
            manifest,
        }
@@ -306,15 +312,18 @@ impl Package {
        let mut gzip = builder.into_inner().await?;
        gzip.shutdown().await?;
 
-       //// probably not explicitly required; however, makes the test suite pass so...
+       // probably not explicitly required; however, makes the test suite pass so...
        let mut file = gzip.into_inner();
        file.shutdown().await?;
+
+       let package_hash = compute_sha256_file(&package_path).await?; 
 
        Ok(Self {
            manifest,
            unpacked_path: None,
            tmp_dir: Some(tmp_dir),
            package_file_path: Some(package_path),
+           package_file_hash: Some(package_hash),
        })
    }
 

--- a/crates/tower-package/tests/package_test.rs
+++ b/crates/tower-package/tests/package_test.rs
@@ -201,7 +201,7 @@ async fn it_packages_import_paths() {
     assert!(manifest.import_paths.contains(make_path!("modules", "shared")), "Import paths {:?} did not contain expected path", manifest.import_paths);
 
     // We should have some integrity check here too.
-    assert!(!manifest.integrity_hash.is_empty(), "Manifest integrity check was not set");
+    assert!(!manifest.checksum.is_empty(), "Manifest integrity check was not set");
 }
 
 #[tokio::test]

--- a/crates/tower-package/tests/package_test.rs
+++ b/crates/tower-package/tests/package_test.rs
@@ -199,6 +199,9 @@ async fn it_packages_import_paths() {
     // NOTE: These paths are joined by the OS so we need to be more specific about the expected
     // path.
     assert!(manifest.import_paths.contains(make_path!("modules", "shared")), "Import paths {:?} did not contain expected path", manifest.import_paths);
+
+    // We should have some integrity check here too.
+    assert!(!manifest.integrity_hash.is_empty(), "Manifest integrity check was not set");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR introduces calculating package content integrity checks, as well as overall package integrity checks that are sent to the server. This allows us to figure out what's going on with clients on the server, and return better error messages about potential corruption.