### PR TITLE
Initial check-in of changes to llms() API improving model name resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 *.pyc
 __pycache__
 
+
+.vscode
+
+# may contain sensitive data
+pytest.ini
+
 # 
 # Artifacts from the Rust client generation process
 #

--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ uv run pytest tests
 
 If you need to get the latest OpenAPI SDK, you can run
 `./scripts/generate-python-api-client.sh`.
+
+## Testing
+We use pytest to run tests. Copy `pytest.ini.template` to `pytest.ini` and 
+replace the values of environment variables 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,5 +65,6 @@ dev = [
   "openapi-python-client>=0.12.1",
   "pytest>=8.3.5",
   "pytest-httpx>=0.35.0",
+  "pytest-env>=1.1.3",
   "pyiceberg[sql-sqlite]>=0.9.0",
 ]

--- a/pytest.ini.template
+++ b/pytest.ini.template
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    TOWER_INFERENCE_ROUTER_API_KEY=<hf_1234567890>

--- a/src/tower/_context.py
+++ b/src/tower/_context.py
@@ -1,12 +1,15 @@
 import os
 
 class TowerContext:
-    def __init__(self, tower_url: str, environment: str, api_key: str = None, hugging_face_provider: str = None, hugging_face_api_key: str = None):
+    def __init__(self, tower_url: str, environment: str, api_key: str = None, 
+                 inference_router: str = None, inference_router_api_key: str = None,
+                 inference_service: str = None):
         self.tower_url = tower_url
         self.environment = environment
         self.api_key = api_key
-        self.hugging_face_provider = hugging_face_provider
-        self.hugging_face_api_key = hugging_face_api_key
+        self.inference_router = inference_router
+        self.inference_router_api_key = inference_router_api_key
+        self.inference_service = inference_service
 
     def is_local(self) -> bool:
         if self.environment is None or self.environment == "":
@@ -21,14 +24,19 @@ class TowerContext:
         tower_url = os.getenv("TOWER_URL")
         tower_environment = os.getenv("TOWER_ENVIRONMENT")
         tower_api_key = os.getenv("TOWER_API_KEY")
-        hugging_face_provider = os.getenv("TOWER_HUGGING_FACE_PROVIDER")
-        hugging_face_api_key = os.getenv("TOWER_HUGGING_FACE_API_KEY")
+
+        # Replaces the deprecated hugging_face_provider and hugging_face_api_key
+        inference_router = os.getenv("TOWER_INFERENCE_ROUTER")
+        inference_router_api_key = os.getenv("TOWER_INFERENCE_ROUTER_API_KEY")
+        inference_service = os.getenv("TOWER_INFERENCE_SERVICE")
+
 
         return cls(
             tower_url = tower_url,
             environment = tower_environment,
             api_key = tower_api_key,
-            hugging_face_provider = hugging_face_provider,
-            hugging_face_api_key = hugging_face_api_key,
+            inference_router = inference_router,
+            inference_router_api_key = inference_router_api_key,
+            inference_service = inference_service,
         )
 

--- a/src/tower/_llms.py
+++ b/src/tower/_llms.py
@@ -3,78 +3,457 @@ from typing import List
 from ollama import chat, pull
 from ollama import ChatResponse
 from ollama import ResponseError
+from ollama import list as ollama_list_models
+#import psutil # TODO: add this back in when implementing memory checking for LLMs
 
 from huggingface_hub import InferenceClient, ChatCompletionOutput
+from huggingface_hub import HfApi
 
 from ._context import TowerContext
 
-"""
-OLLAMA_MODELS and HUGGING_FACE_MODELS are dictionaries that map published model
-names to the internal names used by Tower when routing LLM requests to the
-underlying provider.
-"""
-OLLAMA_MODELS = {
-    "deepseek-r1": "deepseek-r1:14b",
-}
+LOCAL_INFERENCE_ROUTERS = [
+    "ollama", 
+    "vllm",
+]
 
-HUGGING_FACE_MODELS = {
-    "deepseek-r1": "deepseek-ai/DeepSeek-R1",
-}
+INFERENCE_ROUTERS = LOCAL_INFERENCE_ROUTERS + [
+    "hugging_face_hub"
+]
 
-def extract_model_name(ctx: TowerContext, supported_model: str) -> str:
+RAW_MODEL_FAMILIES = [
+    "all-minilm",
+    "aya",
+    "aya-expanse",
+    "athene-v2",
+    "bakllava",
+    "bge-large",
+    "bge-m3",
+    "cogito",
+    "codegemma",
+    "codegeex4",
+    "codeqwen",
+    "codestral",
+    "codeup",
+    "codellama",
+    "command-a",
+    "command-r",
+    "command-r-plus",
+    "command-r7b",
+    "deepcoder",
+    "deepseek-coder",
+    "deepseek-coder-v2",
+    "deepseek-llm",
+    "deepseek-r1",
+    "deepseek-v2",
+    "deepseek-v2.5",
+    "deepseek-v3",
+    "deepscaler",
+    "devstral",
+    "dbrx",
+    "dolphin-mistral",
+    "dolphin-mixtral",
+    "dolphin-phi",
+    "dolphin3",
+    "dolphincoder",
+    "exaone-deep",
+    "exaone3.5",
+    "everythinglm",
+    "falcon",
+    "falcon3",
+    "gemma",
+    "gemma2",
+    "gemma3",
+    "gemma3n",
+    "glm4",
+    "goliath",
+    "granite-code",
+    "granite-embedding",
+    "granite3-dense",
+    "granite3-guardian",
+    "granite3-moe",
+    "granite3.1-dense",
+    "granite3.1-moe",
+    "granite3.2",
+    "granite3.2-vision",
+    "granite3.3",
+    "hermes3",
+    "internlm2",
+    "lafrican",
+    "llama-pro",
+    "llama-guard3",
+    "llama2",
+    "llama2-chinese",
+    "llama2-uncensored",
+    "llama3",
+    "llama3-chatqa",
+    "llama3-groq-tool-use",
+    "llama3-gradient",
+    "llama3.1",
+    "llama3.2",
+    "llama3.2-vision",
+    "llama3.3",
+    "llama4",
+    "llava",
+    "llava-llama3",
+    "llava-phi3",
+    "magicoder",
+    "magistral",
+    "marco-o1",
+    "mathstral",
+    "meditron",
+    "medllama2",
+    "megadolphin",
+    "minicpm-v",
+    "mistral",
+    "mistral-large",
+    "mistral-nemo",
+    "mistral-openorca",
+    "mistral-small",
+    "mistral-small3.1",
+    "mistral-small3.2",
+    "mistrallite",
+    "moondream",
+    "mxbai-embed-large",
+    "nemotron",
+    "nemotron-mini",
+    "neural-chat",
+    "nexusraven",
+    "notus",
+    "nous-hermes",
+    "nous-hermes2",
+    "nous-hermes2-mixtral",
+    "nomic-embed-text",
+    "notux",
+    "olmo2",
+    "opencoder",
+    "openchat",
+    "openthinker",
+    "openhermes",
+    "orca-mini",
+    "orca2",
+    "paraphrase-multilingual",
+    "phi",
+    "phi3",
+    "phi3.5",
+    "phi4",
+    "phi4-mini",
+    "phi4-mini-reasoning",
+    "phi4-reasoning",
+    "phind-codellama",
+    "qwen",
+    "qwen2",
+    "qwen2-math",
+    "qwen2.5",
+    "qwen2.5-coder",
+    "qwen2.5vl",
+    "qwen3",
+    "qwq",
+    "r1-1776",
+    "reader-lm",
+    "reflection",
+    "sailor2",
+    "samatha-mistral",
+    "shieldgemma",
+    "smallthinker",
+    "smollm",
+    "smollm2",
+    "snowflake-arctic-embed",
+    "snowflake-arctic-embed2",
+    "solar",
+    "solar-pro",
+    "sqlcoder",
+    "stable-beluga",
+    "stable-code",
+    "stablelm-zephyr",
+    "stablelm2",
+    "starcoder",
+    "starcoder2",
+    "starling-lm",
+    "sunbeam",
+    "tulu3",
+    "tinydolphin",
+    "tinyllama",
+    "vicuna",
+    "wizard-math",
+    "wizard-vicuna",
+    "wizard-vicuna-uncensored",
+    "wizardcoder",
+    "wizardlm",
+    "wizardlm-uncensored",
+    "wizardlm2",
+    "xwinlm",
+    "yarn-llama2",
+    "yarn-mistral",
+    "yi",
+    "yi-coder",
+    "zephyr"
+]
+
+def normalize_model_family(name: str) -> str:
     """
-    extract_model_name maps the relevant supported model into a model for the
-    underlying LLM provider that we want to use.
+    Normalize a model family name by removing '-' and '.' characters.
+    Args:
+        name (str): The model family name to normalize.
+    Returns:
+        str: The normalized model family name.
     """
-    if ctx.is_local():
-        if supported_model not in OLLAMA_MODELS:
-            raise ValueError(f"Model {supported_model} not supported for Ollama.")
-        return OLLAMA_MODELS[supported_model]
+    return name.replace('-', '').replace('.', '').lower()
+
+
+MODEL_FAMILIES = {normalize_model_family(name) : name for name in RAW_MODEL_FAMILIES}
+
+# the %-ge of memory that we can use for inference
+# TODO: add this back in when implementing memory checking for LLMs
+# MEMORY_THRESHOLD = 0.8
+
+
+
+def parse_parameter_size(size_str: str) -> float:
+    """
+    Convert parameter size string (e.g., '8.0B', '7.2B') to number of parameters.
+    """
+    if not size_str:
+        return 0
+    multiplier = {'B': 1e9, 'M': 1e6, 'K': 1e3}
+    size_str = size_str.upper()
+    for suffix, mult in multiplier.items():
+        if suffix in size_str:
+            return float(size_str.replace(suffix, '')) * mult
+    return float(size_str)
+
+
+def resolve_model_name(ctx: TowerContext, requested_model: str) -> str:
+  
+    if ctx.inference_router not in INFERENCE_ROUTERS:
+        raise ValueError(f"Inference router {ctx.inference_router} not supported.")
+
+    if ctx.inference_router == "ollama":
+        return resolve_ollama_model_name(ctx,requested_model)
+    elif ctx.inference_router == "vllm":
+        return resolve_vllm_model_name(ctx,requested_model)
+    elif ctx.inference_router == "hugging_face_hub":
+        return resolve_hugging_face_hub_model_name(ctx,requested_model)
+
+def get_local_ollama_models() -> List[dict]:
+    """
+    Get a list of locally installed Ollama models with their details.
+    Returns a list of dictionaries containing:
+    - name: model name with tag
+    - model_family: model family without tag
+    - size: model size in bytes
+    - parameter_size: number of parameters
+    - quantization_level: quantization level if specified
+    """
+    try:
+        models = ollama_list_models()
+        model_list = []
+        for model in models['models']:
+            model_name = model.get('model', '')
+            model_family = model_name.split(':')[0]
+            size = model.get('size', 0)
+            details = model.get('details', {})
+            parameter_size=details.get('parameter_size', '')
+            quantization_level=details.get('quantization_level', '')
+
+            model_list.append({
+                'model': model_name,
+                'model_family': model_family,
+                'size': size,
+                'parameter_size': parameter_size,
+                'quantization_level': quantization_level
+            })
+        return model_list
+    except Exception as e:
+        raise RuntimeError(f"Failed to list Ollama models: {str(e)}")
+
+
+def resolve_ollama_model_name(ctx: TowerContext, requested_model: str) -> str:
+    """
+    Resolve the Ollama model name to use.
+    """
+    local_models = get_local_ollama_models()
+    local_model_names = [model['model'] for model in local_models]
+    
+    # TODO: add this back in when implementing memory checking for LLMs
+    #memory = get_available_memory()
+    #memory_threshold = memory['available'] * MEMORY_THRESHOLD
+
+    if normalize_model_family(requested_model) in MODEL_FAMILIES:
+        # Filter models by family
+        matching_models = [model for model in local_models if model['model_family'] == requested_model]
+
+        # TODO: add this back in when implementing memory checking for LLMs
+        # Filter models by memory
+        # if check_for_memory:
+        #    matching_models = [model for model in matching_models if model['size'] < memory_threshold]
+
+        # Return the model with the largest parameter size
+        if matching_models:
+            best_model = max(matching_models, key=lambda x: parse_parameter_size(x['parameter_size']))['model']
+            return best_model
+        else:
+            # TODO: add this back in when implementing memory checking for LLMs
+            # raise ValueError(f"No models in family {requested_model} fit in available memory ({memory['available'] / (1024**3):.2f} GB) with max memory threshold {MEMORY_THRESHOLD} or are not available locally. Please pull a model first using 'ollama pull {requested_model}'")
+            raise ValueError(f"No models in family {requested_model} are available locally. Please pull a model first using 'ollama pull {requested_model}'")
+    elif requested_model in local_model_names:
+        return requested_model
     else:
-        if supported_model not in HUGGING_FACE_MODELS:
-            raise ValueError(f"Model {supported_model} not supported for Hugging Face Hub.")
-        return HUGGING_FACE_MODELS[supported_model]
+        raise ValueError(f"Model {requested_model} is not available locally. Please pull it first using 'ollama pull {requested_model}'")
+
+def resolve_vllm_model_name(ctx: TowerContext, requested_model: str) -> str:
+    raise NotImplementedError("vLLM is not supported yet.")
+    return requested_model
+
+def resolve_hugging_face_hub_model_name(ctx: TowerContext, requested_model: str) -> str:
+    """
+    Resolve the Hugging Face Hub model name to use.
+    Returns a list of models with their inference provider mappings.
+    """
+    api = HfApi(token=ctx.inference_router_api_key)
+
+    models = []
+
+    try:
+        model_info = api.model_info(requested_model, expand="inferenceProviderMapping")
+        models = [model_info]
+    except Exception as e:
+        # If model_info fails, fall back to search
+        pass
+
+    # If inference_service is specified, filter by inference provider
+    # We will use search instead of filter because only search allows searching inside the model name
+    # TODO: Add more filtering options e.g. by number of parameters, so that we do not have to retrieve so many models
+    # TODO: We need to retrieve >1 model because "search" returns a full text match in both model IDs and Descriptions
+    
+    if len(models) == 0:
+        if ctx.inference_service is not None:
+            models = api.list_models(
+                search=f"{requested_model}", 
+                inference_provider=ctx.inference_service, 
+                expand="inferenceProviderMapping",
+                limit=10)
+        else:
+            models = api.list_models(
+                search=f"{requested_model}", 
+                expand="inferenceProviderMapping",
+                limit=10)
+
+    # Create a list of models with their inference provider mappings
+    model_list = []
+    try:
+        for model in models:
+            model_info = {
+                'model_name': model.id,
+                'inference_providers': model.inference_provider_mapping
+            }
+            
+            # If inference_service is specified, only add models that support it
+            if ctx.inference_service is not None:
+                if ctx.inference_service not in [mapping.provider for mapping in model.inference_provider_mapping]:
+                    continue
+            
+            # Check that requested_model is partially contained in model.id
+            if normalize_model_family(requested_model) not in normalize_model_family(model.id):
+                continue
+            
+            model_list.append(model_info)
+    except Exception as e:
+        raise RuntimeError(f"Error while iterating: {str(e)}")
+
+    if not model_list:
+        raise ValueError(f"No models found matching '{requested_model}' on Hugging Face Hub")
+    
+    return model_list[0]['model_name']
+
 
 class Llm:
     def __init__(self, context: TowerContext, model_name: str, max_tokens: int = 1000):
         """
         Wraps up interfacing with a language model in the Tower system.
         """
-        self.model_name = model_name
+        self.requested_model_name = model_name
         self.max_tokens = max_tokens
         self.context = context
 
-    def inference(self, messages: List) -> str:
-        """
-        Simulate the inference process of a language model.
-        In a real-world scenario, this would involve calling an API or using a library to get the model's response.
-        """
-        model_name = extract_model_name(self.context, self.model_name)
+        self.inference_router = context.inference_router
+        self.inference_router_api_key = getattr(context,'inference_router_api_key', None)
+        self.inference_service = context.inference_service
 
-        if self.context.is_local():
-            # Use Ollama for local inference using Apple GPUs
-            response = infer_with_ollama(
+        if self.inference_router is None and self.context.is_local():
+            self.inference_router = "ollama"
+
+        # for local routers, the service is also the router
+        if self.inference_router in LOCAL_INFERENCE_ROUTERS:
+            self.inference_service = self.inference_router
+
+        # Check that we know this router. This will also check that router was set when not in local mode.
+        if context.inference_router not in INFERENCE_ROUTERS:
+            raise ValueError(f"Inference router {context.inference_router} not supported.")
+        
+        self.model_name = resolve_model_name(
+            self.context, self.requested_model_name)
+        
+
+    def chat_completion(self, messages: List) -> str:
+        """
+        Mimics the OpenAI Chat Completions API by sending a list of messages to the language model
+        and returning the generated response.
+        
+        This function provides a unified interface for chat-based interactions with different
+        language model providers (Ollama, Hugging Face Hub, etc.) while maintaining compatibility
+        with the OpenAI Chat Completions API format.
+        
+        Args:
+            messages: A list of message dictionaries, each containing 'role' and 'content' keys.
+                     Follows the OpenAI Chat Completions API message format.
+                     
+        Returns:
+            str: The generated response from the language model.
+            
+        Example:
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello, how are you?"}
+            ]
+            response = llm.chat_completion(messages)
+        """
+
+        if self.inference_router == "ollama":
+            # Use Ollama for local inference
+            response = chat_completion_with_ollama(
                 ctx = self.context,
-                model = model_name,
+                model = self.model_name,
                 messages = messages
             )
-        else:
-            max_tokens = self.max_tokens
-            response = infer_with_hugging_face_hub(
+        elif self.inference_router == "hugging_face_hub":
+            response = chat_completion_with_hugging_face_hub(
                 ctx = self.context,
-                model = model_name,
+                model = self.model_name,
                 messages = messages, 
-                max_tokens=max_tokens
+                max_tokens=self.max_tokens
             )
 
         return response
 
     def prompt(self, prompt: str) -> str:
         """
-        Prompt a language model with a string. This basically will format the
-        relevant messages internally to send to the model.
+        Mimics the old-style OpenAI Completions API (not Chat Completions!) by sending a single prompt string 
+        to the language model and returning the generated response.
+        
+        This function provides a simple interface for single-prompt interactions, similar to the
+        legacy OpenAI /v1/completions endpoint. It internally converts the prompt to a chat message
+        format and uses the chat_completion method.
+        
+        Args:
+            prompt: A single string containing the prompt to send to the language model.
+                   
+        Returns:
+            str: The generated response from the language model.
+            
+        Example:
+            response = llm.prompt("What is the capital of France?")
         """
-        return self.inference([{
+        return self.chat_completion([{
             "role": "user",
             "content": prompt,
         }])
@@ -92,7 +471,10 @@ def extract_ollama_message(resp: ChatResponse) -> str:
 def extract_hugging_face_hub_message(resp: ChatCompletionOutput) -> str:
     return resp.choices[0].message.content
 
-def infer_with_ollama(ctx: TowerContext, model: str, messages: list, is_retry: bool = False) -> str:
+def chat_completion_with_ollama(ctx: TowerContext, model: str, messages: list, is_retry: bool = False) -> str:
+    
+    # TODO: remove the try/except and don't pull the model if it doesn't exist. sso 7/20/25
+
     try:
         response: ChatResponse = chat(model=model, messages=messages)
         return extract_ollama_message(response)
@@ -103,20 +485,20 @@ def infer_with_ollama(ctx: TowerContext, model: str, messages: list, is_retry: b
             pull(model=model)
 
             # Retry the inference after the model hasbeen pulled.
-            return infer_with_ollama(ctx, model, messages, is_retry=True)
+            return chat_completion_with_ollama(ctx, model, messages, is_retry=True)
 
         # Couldn't figure out what the error was, so we'll just raise it accordingly.
         raise e
 
-def infer_with_hugging_face_hub(ctx: TowerContext, model: str, messages: List, **kwargs) -> str:
+def chat_completion_with_hugging_face_hub(ctx: TowerContext, model: str, messages: List, **kwargs) -> str:
     """
     Uses the Hugging Face Hub API to perform inference. Will use configuration
     supplied by the environment to determine which client to connect to and all
     that.
     """
     client = InferenceClient(
-        provider=ctx.hugging_face_provider,
-        api_key=ctx.hugging_face_api_key
+        provider=ctx.inference_service,
+        api_key=ctx.inference_router_api_key
     )
 
     completion = client.chat_completion(messages,
@@ -125,3 +507,28 @@ def infer_with_hugging_face_hub(ctx: TowerContext, model: str, messages: List, *
     )
 
     return extract_hugging_face_hub_message(completion)
+
+
+# TODO: add this back in when implementing memory checking for LLMs
+# TODO: add this back in when implementing memory checking for LLMs
+# def get_available_memory() -> dict:
+#     """
+#     Get available system memory information.
+#     Returns a dictionary containing:
+#     - total: total physical memory in bytes
+#     - available: available memory in bytes
+#     - used: used memory in bytes
+#     - percent: memory usage percentage
+#     """
+#     try:
+#         memory = psutil.virtual_memory()
+#         return {
+#             'total': memory.total,
+#             'available': memory.available,
+#             'used': memory.used,
+#             'percent': memory.percent
+#         }
+#     except Exception as e:
+#         raise RuntimeError(f"Failed to get memory information: {str(e)}")
+
+

--- a/tests/tower/test_env.py
+++ b/tests/tower/test_env.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import platform
+
+
+def test_environment_variables():
+    """Test to show environment variable values during test execution."""
+    print(f"Python version: {sys.version}")
+    print(f"Python executable: {sys.executable}")
+    print(f"Platform: {platform.platform()}")
+    print(f"Current working directory: {os.getcwd()}")
+    print(f"PYTHONPATH: {os.getenv('PYTHONPATH', 'Not set')}")
+    print(f"Virtual environment: {os.getenv('VIRTUAL_ENV', 'Not in virtual env')}")
+    print(f"PYENV_VERSION: {os.getenv('PYENV_VERSION', 'Not set')}")
+    print("-" * 50)
+    
+    # Check if environment variables from pytest.ini are available
+    router_key = os.getenv("TOWER_INFERENCE_ROUTER_API_KEY")
+    
+    # Check if pytest-env is working
+    if router_key is not None:
+        assert router_key.startswith("hf_"), f"Expected router key to start with 'hf_', got {router_key}"

--- a/tests/tower/test_llms.py
+++ b/tests/tower/test_llms.py
@@ -1,0 +1,219 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from tower._llms import llms, Llm
+from tower._context import TowerContext
+
+@pytest.fixture
+def mock_ollama_context():
+    """Create a mock TowerContext for testing."""
+    context = MagicMock(spec=TowerContext)
+    context.is_local.return_value = True
+    context.inference_router = "ollama"
+    context.inference_service = "ollama"
+    context.inference_router_api_key = None
+    return context
+
+@pytest.fixture
+def mock_hf_together_context():
+    """Create a mock TowerContext for Hugging Face Hub testing."""
+    context = MagicMock(spec=TowerContext)
+    context.is_local.return_value = False
+    context.inference_router = "hugging_face_hub"
+    context.inference_router_api_key = os.getenv("TOWER_INFERENCE_ROUTER_API_KEY")
+    context.inference_service = "together"
+    return context
+
+@pytest.fixture
+def mock_hf_context():
+    """Create a mock TowerContext for Hugging Face Hub testing."""
+    context = MagicMock(spec=TowerContext)
+    context.is_local.return_value = False
+    context.inference_router = "hugging_face_hub"
+    context.inference_router_api_key = os.getenv("TOWER_INFERENCE_ROUTER_API_KEY")
+    context.inference_service = None
+    return context
+
+
+@pytest.fixture
+def mock_ollama_response():
+    """Create a mock Ollama response."""
+    response = MagicMock()
+    response.message.content = "This is a test response"
+    return response
+
+def test_llms_nameres_with_model_family_locally_1(mock_ollama_context, mock_ollama_response):
+    """
+    Test resolving a model family name to a particular model.
+    Run this test with ollama locally installed.
+    deepseek-r1 is a name that is used by both ollama and HF
+    """
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_ollama_context):
+        # Mock the chat function to return our mock response
+        with patch('tower._llms.chat', return_value=mock_ollama_response):
+            
+            # Create LLM instance based on model family name
+            llm = llms("deepseek-r1")
+            
+            # Verify it's an Llm instance
+            assert isinstance(llm, Llm)
+
+            # Verify the resolved model was found locally
+            assert llm.model_name.startswith("deepseek-r1:")
+            
+def test_llms_nameres_with_model_family_on_hugging_face_hub_1(mock_hf_together_context):
+    """
+    Test resolving a model family name to a particular model.
+    Run this test against models available on Hugging Face Hub.
+    deepseek-r1 is a name that is used by both ollama and HF
+    """
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_hf_together_context):
+        
+        with patch('tower._llms.InferenceClient') as mock_client:
+            
+            # Create LLM instance
+            llm = llms("deepseek-r1")
+            
+            # Verify it's an Llm instance
+            assert isinstance(llm, Llm)
+
+            # Verify the resolved model was found on the Hub
+            assert llm.model_name.startswith("deepseek-ai")
+            
+
+def test_llms_nameres_with_model_family_locally_2(mock_ollama_context, mock_ollama_response):
+    """
+    Test resolving a model family name to a particular model.
+    Run this test with ollama locally installed.
+    llama3.2 is a name used by ollama.
+    Llama-3.2 is a name used on HF.
+    """
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_ollama_context):
+        # Mock the chat function to return our mock response
+        with patch('tower._llms.chat', return_value=mock_ollama_response):
+            
+            # Create LLM instance based on model family name
+            llm = llms("llama3.2")
+            
+            # Verify it's an Llm instance
+            assert isinstance(llm, Llm)
+
+            # Verify the resolved model was found locally
+            assert llm.model_name.startswith("llama3.2:")
+            
+def test_llms_nameres_with_model_family_on_hugging_face_hub_2(mock_hf_together_context):
+    """
+    Test resolving a model family name to a particular model.
+    Run this test against models available on Hugging Face Hub.
+    llama3.2 is a name used by ollama.
+    Llama-3.2 is a name used on HF.
+    """
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_hf_together_context):
+        
+        with patch('tower._llms.InferenceClient') as mock_client:
+            
+            # Create LLM instance
+            llm = llms("llama3.2")
+            
+            # Verify it's an Llm instance
+            assert isinstance(llm, Llm)
+
+            # Verify the resolved model was found on the Hub
+            assert "llama" in llm.model_name
+
+
+
+def test_llms_nameres_with_nonexistent_model_locally(mock_ollama_context):
+    """Test llms function with a model that doesn't exist locally."""
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_ollama_context):
+        # Mock get_local_ollama_models to return empty list
+        with patch('tower._llms.get_local_ollama_models', return_value=[]):
+            # Test with a non-existent model
+            with pytest.raises(ValueError) as exc_info:
+                llms("nonexistent-model")
+            
+            # Verify the error message
+            assert "Model nonexistent-model is not available" in str(exc_info.value)
+
+def test_llms_nameres_with_exact_model_name_on_hugging_face_hub(mock_hf_together_context):
+    """Test finding a particular model on Hugging Face Hub."""
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_hf_together_context):
+        # Mock the Hugging Face Hub client
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock(message=MagicMock(content="This is a test response"))]
+        
+        with patch('tower._llms.InferenceClient') as mock_client:
+            mock_client.return_value.chat_completion.return_value = mock_completion
+            
+            # Create LLM instance
+            llm = llms("deepseek-ai/DeepSeek-R1")
+            
+            # Verify it's an Llm instance
+            assert isinstance(llm, Llm)
+
+            # Verify the context was set
+            assert llm.context == mock_hf_together_context
+
+            # Test a simple prompt
+            response = llm.prompt("Hello, how are you?")
+            assert response == "This is a test response"
+            
+            # Verify the resolved model was found on the Hub
+            assert llm.model_name.startswith("deepseek-ai/DeepSeek-R1")
+
+
+def test_llms_inference_with_hugging_face_hub_1(mock_hf_together_context):
+    """Test actual inference on a model served by together via Hugging Face Hub."""
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_hf_together_context):
+            
+        # Create LLM instance
+        llm = llms("deepseek-ai/DeepSeek-R1")
+            
+        # Test a simple prompt
+        response = llm.prompt("What is your model name?")
+        assert "DeepSeek-R1" in response
+            
+
+def test_llms_inference_locally_1(mock_ollama_context, mock_ollama_response):
+    """Test local inference, but against a stubbed response."""
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_ollama_context):
+        # Mock the chat function to return our mock response
+        with patch('tower._llms.chat', return_value=mock_ollama_response):
+            
+            # Create LLM instance based on model family name
+            llm = llms("deepseek-r1")
+            
+            # Test a simple prompt
+            response = llm.prompt("Hello, how are you?")
+            assert response == "This is a test response"
+            
+
+
+def test_llms_nameres_with_partial_model_name_on_hugging_face_hub(mock_hf_context):
+    """Test llms function with Hugging Face Hub inference."""
+    # Mock the TowerContext.build() to return our mock context
+    with patch('tower._llms.TowerContext.build', return_value=mock_hf_context):
+            
+        # Create LLM instance
+        llm = llms("google/gemma-3")
+            
+        # Verify it's an Llm instance
+        assert isinstance(llm, Llm)
+
+        # Verify the context was set
+        assert llm.context == mock_hf_context
+
+        # Verify the resolved model was found on the Hub
+        assert llm.model_name.startswith("google/gemma-3")
+
+
+


### PR DESCRIPTION
The goals of this PR was to allow developers to use LLMs across their development and production environments just by specifying a short model family name and without having lots of conditional statements handling differences in environments.

E.g. calling llms("llama3.2") should resolve to the model "llama3.2:3b" when working with ollama local inference and to model "meta-llama/Llama-3.2-3B-Instruct" when using Hugging Face Hub serverless inference.

Differences in naming of models, and the fact that each model is actually a collection of dozen of versions that differ in number of parameters (distillation) and quantization techniques made the naming resolution a tricky task.

Here are the new capabilities of the llms() API:

1. Tower now recognizes ~170 names of model families as of August 2025. Btw, there are 100,000+ individual models in these model families

2. Users can specify a model family e.g. llms("deepseek-r1") in both local and Tower cloud environments, and Tower will resolve the model family to a particular model that is available for inference:
- in local environment, Tower will find the model that is installed and, if there are multiple installed, pick the one with the largest number of parameters
- in Tower cloud environments, Tower will take the first model returned by HF search, making sure that this model is servable by the Inference Service, if specified by users

In addition to using model family names, Users can also specify a particular model both in local and Tower cloud environments: 
- locally: llms("deepseek-r1:14b") or llms("llama3.2:latest") 
- serverlessly: llms("deepseek-ai/DeepSeek-R1-0528") or llms("meta-llama/Llama-3.2-3B-Instruct")

Expected use:

A developer wants to use use a model of the "llama3.2" family first in development and then in production. They would add this code to their Tower app:

```
model_name=os.getenv("MODEL_NAME")
llm = llms(model_name)
```

They would set up their environments as follows:

"dev" environment:

Tower Secrets:

MODEL_NAME = "llama3.2"
(any model of this family installed locally will do)

TOWER_INFERENCE_ROUTER=ollama

"prod" environment:

Tower Secrets:

MODEL_NAME = meta-llama/Llama-3.2-3B-Instruct
(use a particular model)

TOWER_INFERENCE_ROUTER=hugging_face_hub
TOWER_INFERENCE_ROUTER_API_KEY=hf_123456789
TOWER_INFERENCE_SERVICE=<together|...>