### PR TITLE
Local apps should terminate themselves when dropped

### DIFF
--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -269,6 +269,13 @@ async fn execute_local_app(opts: StartOptions, sx: oneshot::Sender<i32>, cancel_
     return Ok(())
 } 
 
+impl Drop for LocalApp {
+    fn drop(&mut self) {
+        // We want to ensure that we cancel the process if it is still running.
+        let _ = self.terminate();
+    }
+}
+
 impl App for LocalApp {
     async fn start(opts: StartOptions) -> Result<Self, Error> {
         let cancel_token = CancellationToken::new();

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -78,6 +78,7 @@ impl Uv {
         debug!("Executing UV ({:?}) venv in {:?}", &self.uv_path, cwd);
 
         let child = Command::new(&self.uv_path)
+            .kill_on_drop(true)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -95,6 +96,7 @@ impl Uv {
         if cwd.join("pyproject.toml").exists() {
             debug!("Executing UV ({:?}) sync in {:?}", &self.uv_path, cwd);
             let child = Command::new(&self.uv_path)
+                .kill_on_drop(true)
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
@@ -112,6 +114,7 @@ impl Uv {
 
             // If there is a requirements.txt, then we can use that to sync.
             let child = Command::new(&self.uv_path)
+                .kill_on_drop(true)
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
@@ -138,6 +141,7 @@ impl Uv {
         debug!("Executing UV ({:?}) run {:?} in {:?}", &self.uv_path, program, cwd);
 
         let child = Command::new(&self.uv_path)
+            .kill_on_drop(true)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
Sometimes we end up with orphaned or zombied apps, despite our best efforts. This PR tries to be more aggressive about getting rid of zombie apps in the event of a failure.