### PR TITLE
chore: make armv7-unknown-linux-musleabihf optional

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -320,6 +320,7 @@ jobs:
   musllinux-cross:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.platform.target == 'armv7-unknown-linux-musleabihf' }}
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
armv7-unknown-linux-musleabihf is a [Tier 2 without Host Tools](https://doc.rust-lang.org/beta/rustc/platform-support.html#tier-2-without-host-tools) target. That means that we should expect it to not always build, as they do not provide any guarantees that it will.

Since there's already a arm-unknown-linux-gnueabihf target, I don't think it should be the end of the world if the LLVM version doesn't build - at least there's still a binary for that platform. So in order to deal with the intermittent builds, I'm making this job not block the CI.