### PR TITLE
fix: handle 404s gracefully

### DIFF
--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -169,6 +169,9 @@ fn output_response_content_error<T>(err: ResponseContent<T>) {
         StatusCode::INTERNAL_SERVER_ERROR => {
             error("The Tower API encountered an internal error. Maybe try again later on.");
         },
+        StatusCode::NOT_FOUND => {
+            output_full_error_details(&error_model);
+        },
         StatusCode::UNAUTHORIZED => {
             error("You aren't authorized to do that! Are you logged in? Run `tower login` to login.");
         },


### PR DESCRIPTION
Some of our operations that are not fulfilled for legitimate reasons but don't crash, return a "crash"-type of response to the CLI.
One such case is 404 e.g. deleting an app that doesn't exist.
Adding the case to handle those