### PR TITLE
Fix run regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,6 +3538,7 @@ dependencies = [
  "http",
  "indicatif",
  "promptly",
+ "regex",
  "reqwest",
  "reqwest-eventsource",
  "rmcp",

--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct Parameter{
+pub struct Parameter {
     #[serde(default)]
     pub name: String,
 
@@ -115,7 +115,6 @@ impl Towerfile {
         std::fs::write(target_path, toml::to_string_pretty(self)?)?;
         Ok(())
     }
-
 
     /// add_parameter adds a new parameter to the Towerfile
     pub fn add_parameter(&mut self, name: String, description: String, default: String) {
@@ -277,19 +276,18 @@ mod test {
     fn test_add_parameter() {
         let mut towerfile = crate::Towerfile::default();
         assert_eq!(towerfile.parameters.len(), 0);
-        
+
         towerfile.add_parameter(
             "test-param".to_string(),
             "A test parameter".to_string(),
-            "default-value".to_string()
+            "default-value".to_string(),
         );
-        
+
         assert_eq!(towerfile.parameters.len(), 1);
         assert_eq!(towerfile.parameters[0].name, "test-param");
         assert_eq!(towerfile.parameters[0].description, "A test parameter");
         assert_eq!(towerfile.parameters[0].default, "default-value");
     }
-
 
     #[test]
     fn test_roundtrip_serialization() {
@@ -310,11 +308,11 @@ name = "param2"
 description = "Second parameter"
 default = "value2"
 "#;
-        
+
         let towerfile = crate::Towerfile::from_toml(original_toml).unwrap();
         let serialized = toml::to_string_pretty(&towerfile).unwrap();
         let reparsed = crate::Towerfile::from_toml(&serialized).unwrap();
-        
+
         assert_eq!(towerfile.app.name, reparsed.app.name);
         assert_eq!(towerfile.app.script, reparsed.app.script);
         assert_eq!(towerfile.app.source, reparsed.app.source);

--- a/crates/tower-cmd/Cargo.toml
+++ b/crates/tower-cmd/Cargo.toml
@@ -18,6 +18,7 @@ http = { workspace = true }
 indicatif = { workspace = true }
 promptly = { workspace = true }
 reqwest = { workspace = true }
+regex = "1.0"
 reqwest-eventsource = { workspace = true }
 rpassword = { workspace = true }
 rsa = { workspace = true }

--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -1,13 +1,14 @@
+use std::collections::HashMap;
+
 use config::Config;
 use futures_util::StreamExt;
 use http::StatusCode;
 use reqwest_eventsource::{Event, EventSource};
-use std::collections::HashMap;
 use tokio::sync::mpsc;
-use tower_api::apis::configuration;
-use tower_api::apis::Error;
-use tower_api::apis::ResponseContent;
-use tower_api::models::RunParameter;
+use tower_api::{
+    apis::{configuration, Error, ResponseContent},
+    models::RunParameter,
+};
 use tower_telemetry::debug;
 
 /// Helper trait to extract the successful response data from API responses

--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -730,7 +730,6 @@ impl ResponseEntity for tower_api::apis::default_api::ListEnvironmentsSuccess {
     }
 }
 
-
 pub async fn list_environments(
     config: &Config,
 ) -> Result<

--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -156,7 +156,17 @@ pub async fn run_app(
         },
     };
 
-    unwrap_api_response(tower_api::apis::default_api::run_app(api_config, params)).await
+    match tower_api::apis::default_api::run_app(api_config, params).await {
+        Ok(response) if response.status.is_client_error() || response.status.is_server_error() => {
+            Err(Error::ResponseError(tower_api::apis::ResponseContent {
+                tower_trace_id: response.tower_trace_id,
+                status: response.status,
+                content: response.content,
+                entity: None,
+            }))
+        }
+        response => unwrap_api_response(async { response }).await,
+    }
 }
 
 pub async fn export_secrets(

--- a/crates/tower-cmd/src/apps.rs
+++ b/crates/tower-cmd/src/apps.rs
@@ -1,7 +1,6 @@
 use clap::{value_parser, Arg, ArgMatches, Command};
 use colored::Colorize;
 use config::Config;
-
 use tower_api::models::Run;
 
 use crate::{api, output, util::dates};

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -29,8 +29,11 @@ fn resolve_path(args: &ArgMatches) -> PathBuf {
 }
 
 pub async fn do_deploy(config: Config, args: &ArgMatches) {
-    // Determine the directory to build the package from
     let dir = resolve_path(args);
+    deploy_from_dir(config, dir, auto_create).await;
+}
+
+pub async fn deploy_from_dir(config: Config, dir: PathBuf) {
     debug!("Building package from directory: {:?}", dir);
 
     let path = dir.join("Towerfile");

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -46,7 +46,11 @@ pub async fn do_deploy(config: Config, args: &ArgMatches) {
     }
 }
 
-pub async fn deploy_from_dir(config: Config, dir: PathBuf, auto_create: bool) -> Result<(), crate::Error> {
+pub async fn deploy_from_dir(
+    config: Config,
+    dir: PathBuf,
+    auto_create: bool,
+) -> Result<(), crate::Error> {
     debug!("Building package from directory: {:?}", dir);
 
     let path = dir.join("Towerfile");
@@ -81,7 +85,11 @@ pub async fn deploy_from_dir(config: Config, dir: PathBuf, auto_create: bool) ->
     Ok(())
 }
 
-async fn do_deploy_package(api_config: Configuration, package: Package, towerfile: &Towerfile) -> Result<tower_api::models::DeployAppResponse, crate::Error> {
+async fn do_deploy_package(
+    api_config: Configuration,
+    package: Package,
+    towerfile: &Towerfile,
+) -> Result<tower_api::models::DeployAppResponse, crate::Error> {
     let res = util::deploy::deploy_app_package(&api_config, &towerfile.app.name, package).await;
 
     match res {

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -17,6 +17,12 @@ pub fn deploy_cmd() -> Command {
                 .help("The directory containing the app to deploy")
                 .default_value("."),
         )
+        .arg(
+            Arg::new("auto-create")
+                .long("auto-create")
+                .help("Automatically create app if it doesn't exist")
+                .action(clap::ArgAction::SetTrue),
+        )
         .about("Deploy your latest code to Tower")
 }
 
@@ -30,10 +36,11 @@ fn resolve_path(args: &ArgMatches) -> PathBuf {
 
 pub async fn do_deploy(config: Config, args: &ArgMatches) {
     let dir = resolve_path(args);
+    let auto_create = args.get_flag("auto-create");
     deploy_from_dir(config, dir, auto_create).await;
 }
 
-pub async fn deploy_from_dir(config: Config, dir: PathBuf) {
+pub async fn deploy_from_dir(config: Config, dir: PathBuf, auto_create: bool) {
     debug!("Building package from directory: {:?}", dir);
 
     let path = dir.join("Towerfile");
@@ -47,6 +54,7 @@ pub async fn deploy_from_dir(config: Config, dir: PathBuf) {
                 &api_config,
                 &towerfile.app.name,
                 &towerfile.app.description,
+                auto_create,
             )
             .await
             {

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -1,12 +1,12 @@
+use std::{convert::From, path::PathBuf};
+
 use clap::{Arg, ArgMatches, Command};
 use config::{Config, Towerfile};
-use std::convert::From;
-use std::path::PathBuf;
-
-use crate::{output, util};
 use tower_api::apis::configuration::Configuration;
 use tower_package::{Package, PackageSpec};
 use tower_telemetry::debug;
+
+use crate::{output, util};
 
 pub fn deploy_cmd() -> Command {
     Command::new("deploy")

--- a/crates/tower-cmd/src/environments.rs
+++ b/crates/tower-cmd/src/environments.rs
@@ -36,9 +36,7 @@ pub async fn do_list(config: Config) {
             let envs_data: Vec<Vec<String>> = resp
                 .environments
                 .into_iter()
-                .map(|env| {
-                    vec![env.name]
-                })
+                .map(|env| vec![env.name])
                 .collect();
 
             // Display the table using the existing table function

--- a/crates/tower-cmd/src/error.rs
+++ b/crates/tower-cmd/src/error.rs
@@ -36,6 +36,12 @@ pub enum Error {
     #[snafu(display("Run was cancelled"))]
     RunCancelled,
 
+    #[snafu(display("App crashed during local execution"))]
+    AppCrashed,
+
+    #[snafu(display("API error occurred"))]
+    ApiError,
+
     #[snafu(display("Failed to load Towerfile from {}: {}", path, source))]
     TowerfileLoadFailed { path: String, source: config::Error },
 

--- a/crates/tower-cmd/src/error.rs
+++ b/crates/tower-cmd/src/error.rs
@@ -98,7 +98,7 @@ impl From<crypto::Error> for Error {
 impl From<tower_api::apis::Error<DescribeRunError>> for Error {
     fn from(err: tower_api::apis::Error<DescribeRunError>) -> Self {
         debug!("API error: {:?}", err);
-        Self::UnknownError
+        Self::ApiError
     }
 }
 

--- a/crates/tower-cmd/src/error.rs
+++ b/crates/tower-cmd/src/error.rs
@@ -1,5 +1,5 @@
 use snafu::prelude::*;
-use tower_api::apis::default_api::{DescribeRunError, RunAppError};
+use tower_api::apis::default_api::{DeployAppError, DescribeAppError, DescribeRunError, RunAppError};
 use tower_telemetry::debug;
 
 #[derive(Debug, Snafu)]
@@ -83,6 +83,18 @@ pub enum Error {
         source: tower_api::apis::Error<RunAppError>,
     },
 
+    // API deploy error
+    #[snafu(display("API deploy error: {}", source))]
+    ApiDeployError {
+        source: tower_api::apis::Error<DeployAppError>,
+    },
+
+    // API describe app error
+    #[snafu(display("API describe app error: {}", source))]
+    ApiDescribeAppError {
+        source: tower_api::apis::Error<DescribeAppError>,
+    },
+
     // Channel error
     #[snafu(display("Channel receive error"))]
     ChannelReceiveError,
@@ -150,6 +162,18 @@ impl From<tower_package::Error> for Error {
 impl From<tower_api::apis::Error<RunAppError>> for Error {
     fn from(source: tower_api::apis::Error<RunAppError>) -> Self {
         Self::ApiRunError { source }
+    }
+}
+
+impl From<tower_api::apis::Error<DeployAppError>> for Error {
+    fn from(source: tower_api::apis::Error<DeployAppError>) -> Self {
+        Self::ApiDeployError { source }
+    }
+}
+
+impl From<tower_api::apis::Error<DescribeAppError>> for Error {
+    fn from(source: tower_api::apis::Error<DescribeAppError>) -> Self {
+        Self::ApiDescribeAppError { source }
     }
 }
 

--- a/crates/tower-cmd/src/error.rs
+++ b/crates/tower-cmd/src/error.rs
@@ -1,5 +1,7 @@
 use snafu::prelude::*;
-use tower_api::apis::default_api::{DeployAppError, DescribeAppError, DescribeRunError, RunAppError};
+use tower_api::apis::default_api::{
+    DeployAppError, DescribeAppError, DescribeRunError, RunAppError,
+};
 use tower_telemetry::debug;
 
 #[derive(Debug, Snafu)]

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -6,8 +6,9 @@ mod apps;
 mod deploy;
 mod environments;
 pub mod error;
-mod package;
+mod mcp;
 pub mod output;
+mod package;
 mod run;
 mod schedules;
 mod secrets;
@@ -16,7 +17,6 @@ mod teams;
 mod towerfile_gen;
 mod util;
 mod version;
-mod mcp;
 
 pub use error::Error;
 
@@ -165,10 +165,12 @@ impl App {
                     }
                 }
             }
-            Some(("mcp-server", args)) => mcp::do_mcp_server(sessionized_config, args).await.unwrap_or_else(|e| {
-                eprintln!("MCP server error: {}", e);
-                std::process::exit(1);
-            }),
+            Some(("mcp-server", args)) => mcp::do_mcp_server(sessionized_config, args)
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("MCP server error: {}", e);
+                    std::process::exit(1);
+                }),
             _ => {
                 cmd_clone.print_help().unwrap();
                 std::process::exit(2);

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -541,7 +541,7 @@ impl TowerService {
 
         Self::with_streaming(
             &ctx,
-            || run::do_run_local(config, working_dir, "default", std::collections::HashMap::new(), false),
+            || run::do_run_local(config, working_dir, "default", std::collections::HashMap::new()),
             "App completed successfully",
             "Local run failed",
         ).await
@@ -573,7 +573,7 @@ impl TowerService {
 
         Self::with_streaming_remote(
             &ctx,
-            || run::do_run_remote(config, path, env, params, None),
+            || run::do_run_remote(config, path, env, params, None, true),
             "Remote run completed successfully",
             &app_name,
         ).await

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -284,7 +284,10 @@ impl TowerService {
         drop(streaming.sender);
         streaming.task.await.ok();
 
-        let output_lines = streaming.collected.lock().ok()
+        let output_lines = streaming
+            .collected
+            .lock()
+            .ok()
             .map(|output| output.clone())
             .unwrap_or_default();
 
@@ -327,7 +330,10 @@ impl TowerService {
         drop(streaming.sender);
         streaming.task.await.ok();
 
-        let output_lines = streaming.collected.lock().ok()
+        let output_lines = streaming
+            .collected
+            .lock()
+            .ok()
             .map(|output| output.clone())
             .unwrap_or_default();
 
@@ -344,7 +350,10 @@ impl TowerService {
                 let error_text = if output_lines.is_empty() {
                     let api_error = Self::extract_api_error_message(&e);
                     if Self::is_deployment_error(&api_error) {
-                        format!("App '{}' not deployed. Try running tower_deploy first.", app_name)
+                        format!(
+                            "App '{}' not deployed. Try running tower_deploy first.",
+                            app_name
+                        )
                     } else {
                         api_error
                     }
@@ -366,7 +375,9 @@ impl TowerService {
             })
     }
 
-    fn load_towerfile_from_dir(working_dir: &std::path::PathBuf) -> Result<Towerfile, config::Error> {
+    fn load_towerfile_from_dir(
+        working_dir: &std::path::PathBuf,
+    ) -> Result<Towerfile, config::Error> {
         Towerfile::from_dir_str(working_dir.to_str().unwrap())
     }
 
@@ -593,9 +604,7 @@ impl TowerService {
     ) -> Result<CallToolResult, McpError> {
         let working_dir = Self::resolve_working_directory(&request.common);
         match deploy::deploy_from_dir(self.config.clone(), working_dir, true).await {
-            Ok(()) => {
-                Self::text_success("Deploy completed successfully".to_string())
-            }
+            Ok(()) => Self::text_success("Deploy completed successfully".to_string()),
             Err(e) => Self::error_result("Deploy failed", e),
         }
     }
@@ -635,7 +644,6 @@ impl TowerService {
         Parameters(request): Parameters<RunRequest>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-
         let config = self.config.clone();
         let working_dir = Self::resolve_working_directory(&request.common);
         let env = "default";

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -607,7 +607,7 @@ impl TowerService {
         Parameters(request): Parameters<EmptyRequest>,
     ) -> Result<CallToolResult, McpError> {
         let working_dir = Self::resolve_working_directory(&request.common);
-        deploy::deploy_from_dir(self.config.clone(), working_dir).await;
+        deploy::deploy_from_dir(self.config.clone(), working_dir, true).await;
         Self::text_success("Deploy command completed - check output above for status".to_string())
     }
 

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -592,8 +592,12 @@ impl TowerService {
         Parameters(request): Parameters<EmptyRequest>,
     ) -> Result<CallToolResult, McpError> {
         let working_dir = Self::resolve_working_directory(&request.common);
-        deploy::deploy_from_dir(self.config.clone(), working_dir, true).await;
-        Self::text_success("Deploy command completed - check output above for status".to_string())
+        match deploy::deploy_from_dir(self.config.clone(), working_dir, true).await {
+            Ok(()) => {
+                Self::text_success("Deploy completed successfully".to_string())
+            }
+            Err(e) => Self::error_result("Deploy failed", e),
+        }
     }
 
     #[tool(

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -29,7 +29,7 @@ pub enum LogLineType {
     Local,
 }
 
-fn format_timestamp(timestamp: &str, t: LogLineType) -> String {
+pub fn format_timestamp(timestamp: &str, t: LogLineType) -> String {
     let ts = timestamp.bold();
 
     let sep = "|".bold();

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -5,7 +5,10 @@ use cli_table::{
 };
 use colored::Colorize;
 use http::StatusCode;
+use regex::Regex;
 use std::io::{self, Write};
+use std::sync::OnceLock;
+use tokio::sync::mpsc::UnboundedSender;
 use tower_api::{
     apis::{Error as ApiError, ResponseContent},
     models::ErrorModel,
@@ -14,8 +17,14 @@ use tower_telemetry::debug;
 
 const BANNER_TEXT: &str = include_str!("./banner.txt");
 
+static CAPTURE_SENDER: OnceLock<UnboundedSender<String>> = OnceLock::new();
+
+pub fn set_capture_sender(sender: UnboundedSender<String>) {
+    CAPTURE_SENDER.set(sender).ok();
+}
+
 pub fn success(msg: &str) {
-    let line = format!("{} {}\n", "Success!".green(), msg);
+    let line = format!("{} {msg}\n", "Success!".green());
     write(&line);
 }
 
@@ -101,39 +110,45 @@ pub fn config_error(err: config::Error) {
 }
 
 pub fn write(msg: &str) {
-    io::stdout().write_all(msg.as_bytes()).unwrap();
+    if let Some(tx) = CAPTURE_SENDER.get() {
+        let re = Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+        let clean_msg = re.replace_all(msg, "").trim_end().to_string();
+        tx.send(clean_msg).ok();
+    } else {
+        io::stdout().write_all(msg.as_bytes()).unwrap();
+    }
 }
 
 pub fn error(msg: &str) {
     let line = format!("{} {}\n", "Oh no!".red(), msg);
-    io::stdout().write_all(line.as_bytes()).unwrap();
+    write(&line);
 }
 
 pub fn runtime_error(err: tower_runtime::errors::Error) {
     let line = format!("{} {}\n", "Runtime Error:".red(), err.to_string());
-    io::stdout().write_all(line.as_bytes()).unwrap();
+    write(&line);
 }
 
 // Outputs both the model.detail and the model.errors fields in a human readable format.
 pub fn output_full_error_details(model: &ErrorModel) {
     // Show the main detail message if available
     if let Some(detail) = &model.detail {
-        writeln!(io::stdout(), "\n{}", "Error details:".yellow()).unwrap();
-        writeln!(io::stdout(), "{}", detail.red()).unwrap();
+        write(&format!("\n{}\n", "Error details:".yellow()));
+        write(&format!("{}\n", detail.red()));
     }
 
     // Show any additional error details from the errors field
     if let Some(errors) = &model.errors {
         if !errors.is_empty() {
             if model.detail.is_none() {
-                writeln!(io::stdout(), "\n{}", "Error details:".yellow()).unwrap();
+                write(&format!("\n{}\n", "Error details:".yellow()));
             }
             for error in errors {
                 let msg = format!(
                     "  • {}",
                     error.message.as_deref().unwrap_or("Unknown error")
                 );
-                writeln!(io::stdout(), "{}", msg.red()).unwrap();
+                write(&format!("{}\n", msg.red()));
             }
         }
     }
@@ -150,8 +165,8 @@ fn output_response_content_error<T>(err: ResponseContent<T>) {
             debug!("Failed to parse error content as JSON: {}", e);
             debug!("Raw error content: {}", err.content);
             // Show the raw error content if JSON parsing fails
-            writeln!(io::stdout(), "\n{}", "API Error:".yellow()).unwrap();
-            writeln!(io::stdout(), "{}", err.content.red()).unwrap();
+            write(&format!("\n{}\n", "API Error:".yellow()));
+            write(&format!("{}\n", err.content.red()));
             return;
         }
     };
@@ -220,7 +235,7 @@ pub fn list(items: Vec<String>) {
         let line = format!(" * {}\n", item);
         let line = line.replace("\n", "\n   ");
         let line = format!("{}\n", line);
-        io::stdout().write_all(line.as_bytes()).unwrap();
+        write(&line);
     }
 }
 
@@ -230,25 +245,35 @@ pub fn banner() {
 
 pub struct Spinner {
     msg: String,
-    spinner: spinners::Spinner,
+    spinner: Option<spinners::Spinner>,
 }
 
 impl Spinner {
     pub fn new(msg: String) -> Spinner {
-        let spinner = spinners::Spinner::new(spinners::Spinners::Dots, msg.clone());
-        Spinner { spinner, msg }
+        if CAPTURE_SENDER.get().is_some() {
+            Spinner { spinner: None, msg }
+        } else {
+            let spinner = spinners::Spinner::new(spinners::Spinners::Dots, msg.clone());
+            Spinner { spinner: Some(spinner), msg }
+        }
     }
 
     pub fn success(&mut self) {
-        let sym = "✔".bold().green().to_string();
-        self.spinner
-            .stop_and_persist(&sym, format!("{} Done!", self.msg));
+        if let Some(ref mut spinner) = self.spinner {
+            let sym = "✔".bold().green().to_string();
+            spinner.stop_and_persist(&sym, format!("{} Done!", self.msg));
+        } else if let Some(tx) = CAPTURE_SENDER.get() {
+            tx.send(format!("{} Done!", self.msg)).ok();
+        }
     }
 
     pub fn failure(&mut self) {
-        let sym = "✘".bold().red().to_string();
-        self.spinner
-            .stop_and_persist(&sym, format!("{} Failed!", self.msg));
+        if let Some(ref mut spinner) = self.spinner {
+            let sym = "✘".bold().red().to_string();
+            spinner.stop_and_persist(&sym, format!("{} Failed!", self.msg));
+        } else if let Some(tx) = CAPTURE_SENDER.get() {
+            tx.send(format!("{} Failed!", self.msg)).ok();
+        }
     }
 }
 
@@ -269,18 +294,18 @@ pub fn write_update_message(latest: &str, current: &str) {
         "To upgrade, run: pip install --upgrade tower".yellow()
     );
 
-    io::stdout().write_all(line.as_bytes()).unwrap();
+    write(&line);
 }
 
 /// newline just outputs a newline. This is useful when you have a very specific formatting you
 /// want to maintain and you don't want to use println!.
 pub fn newline() {
-    io::stdout().write_all("\n".as_bytes()).unwrap();
+    write("\n");
 }
 
 pub fn die(msg: &str) -> ! {
     let line = format!("{} {}\n", "Error:".red(), msg);
-    io::stdout().write_all(line.as_bytes()).unwrap();
+    write(&line);
     std::process::exit(1);
 }
 

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -1,4 +1,8 @@
-pub use cli_table::{format::Justify, Cell};
+use std::{
+    io::{self, Write},
+    sync::{Mutex, OnceLock},
+};
+
 use cli_table::{
     format::{Border, HorizontalLine, Separator},
     print_stdout, Table,
@@ -6,14 +10,14 @@ use cli_table::{
 use colored::Colorize;
 use http::StatusCode;
 use regex::Regex;
-use std::io::{self, Write};
-use std::sync::{OnceLock, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 use tower_api::{
     apis::{Error as ApiError, ResponseContent},
     models::ErrorModel,
 };
 use tower_telemetry::debug;
+
+pub use cli_table::{format::Justify, Cell};
 
 const BANNER_TEXT: &str = include_str!("./banner.txt");
 
@@ -271,7 +275,10 @@ impl Spinner {
             Spinner { spinner: None, msg }
         } else {
             let spinner = spinners::Spinner::new(spinners::Spinners::Dots, msg.clone());
-            Spinner { spinner: Some(spinner), msg }
+            Spinner {
+                spinner: Some(spinner),
+                msg,
+            }
         }
     }
 

--- a/crates/tower-cmd/src/package.rs
+++ b/crates/tower-cmd/src/package.rs
@@ -30,7 +30,10 @@ pub fn package_cmd() -> Command {
 
 pub async fn do_package(_config: Config, args: &ArgMatches) {
     // Determine the directory to build the package from
-    let dir = PathBuf::from(args.get_one::<String>("dir").expect("dir argument should have default value"));
+    let dir = PathBuf::from(
+        args.get_one::<String>("dir")
+            .expect("dir argument should have default value"),
+    );
     debug!("Building package from directory: {:?}", dir);
 
     let path = dir.join("Towerfile");
@@ -43,14 +46,19 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
             match Package::build(spec).await {
                 Ok(package) => {
                     spinner.success();
-                    
+
                     // Get the output path
-                    let output_path = args.get_one::<String>("output").expect("output path is required");
-                    
+                    let output_path = args
+                        .get_one::<String>("output")
+                        .expect("output path is required");
+
                     // Save the package
                     match save_package(&package, output_path).await {
                         Ok(_) => {
-                            output::success(&format!("Package created successfully: {}", output_path));
+                            output::success(&format!(
+                                "Package created successfully: {}",
+                                output_path
+                            ));
                         }
                         Err(err) => {
                             output::error(&format!("Failed to save package: {}", err));
@@ -69,19 +77,24 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
     }
 }
 
-async fn save_package(package: &Package, output_path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let package_path = package.package_file_path.as_ref()
+async fn save_package(
+    package: &Package,
+    output_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let package_path = package
+        .package_file_path
+        .as_ref()
         .ok_or("No package file path found")?;
-    
+
     let output_path = PathBuf::from(output_path);
-    
+
     // Create parent directories if they don't exist
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    
+
     // Copy the package file to the specified location
     fs::copy(package_path, &output_path).await?;
-    
+
     Ok(())
 }

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -558,7 +558,8 @@ fn create_pyiceberg_catalog_property_name(catalog_name: &str, property_name: &st
 /// if it's started yet.
 async fn wait_for_run_start(config: &Config, run: &Run) -> Result<(), Error> {
     loop {
-        let res = api::describe_run(config, &run.app_name, run.number).await
+        let res = api::describe_run(config, &run.app_name, run.number)
+            .await
             .map_err(|api_err| {
                 output::tower_error(api_err);
                 Error::RunFailed

--- a/crates/tower-cmd/src/schedules.rs
+++ b/crates/tower-cmd/src/schedules.rs
@@ -1,11 +1,11 @@
+use std::collections::HashMap;
+
 use clap::{value_parser, Arg, ArgMatches, Command};
 use colored::Colorize;
 use config::Config;
-use std::collections::HashMap;
+use tower_api::models::schedule::Status;
 
 use crate::{api, output};
-
-use tower_api::models::schedule::Status;
 
 pub fn schedules_cmd() -> Command {
     Command::new("schedules")

--- a/crates/tower-cmd/src/secrets.rs
+++ b/crates/tower-cmd/src/secrets.rs
@@ -3,7 +3,6 @@ use colored::Colorize;
 use config::Config;
 use crypto::encrypt;
 use rsa::pkcs1::DecodeRsaPublicKey;
-
 use tower_api::{
     apis::{default_api::CreateSecretError, Error},
     models::CreateSecretResponse,

--- a/crates/tower-cmd/src/session.rs
+++ b/crates/tower-cmd/src/session.rs
@@ -1,11 +1,10 @@
-use crate::output;
 use clap::Command;
 use config::{Config, Session};
 use tokio::{time, time::Duration};
 use tower_api::models::CreateDeviceLoginTicketResponse;
 use tower_telemetry::debug;
 
-use crate::api;
+use crate::{api, output};
 
 pub fn login_cmd() -> Command {
     Command::new("login").about("Create a session with Tower")

--- a/crates/tower-cmd/src/towerfile_gen.rs
+++ b/crates/tower-cmd/src/towerfile_gen.rs
@@ -1,6 +1,6 @@
+use std::{fs, path::Path};
+
 use crate::Error;
-use std::fs;
-use std::path::Path;
 
 pub struct TowerfileGenerator;
 
@@ -180,12 +180,10 @@ name = "custom-script-project"
         let result =
             TowerfileGenerator::from_pyproject(Some("/nonexistent/path/pyproject.toml"), None);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("pyproject.toml not found")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("pyproject.toml not found"));
     }
 
     #[test]
@@ -205,12 +203,10 @@ requires = ["setuptools"]
         let result =
             TowerfileGenerator::from_pyproject(Some(pyproject_path.to_str().unwrap()), None);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("No [project] section found")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No [project] section found"));
     }
 
     #[test]

--- a/crates/tower-cmd/src/util/apps.rs
+++ b/crates/tower-cmd/src/util/apps.rs
@@ -14,6 +14,7 @@ pub async fn ensure_app_exists(
     api_config: &Configuration,
     app_name: &str,
     description: &str,
+    auto_create: bool,
 ) -> Result<(), tower_api::apis::Error<default_api::DescribeAppError>> {
     // Try to describe the app first
     let describe_result = default_api::describe_app(
@@ -51,8 +52,8 @@ pub async fn ensure_app_exists(
         return Err(err);
     }
 
-    // Prompt the user to create the app
-    let create_app = prompt_default(
+    // Decide whether to create the app
+    let create_app = auto_create || prompt_default(
         format!(
             "App '{}' does not exist. Would you like to create it?",
             app_name

--- a/crates/tower-cmd/src/util/apps.rs
+++ b/crates/tower-cmd/src/util/apps.rs
@@ -1,11 +1,14 @@
-use crate::output;
 use http::StatusCode;
 use promptly::prompt_default;
-use tower_api::apis::{
-    configuration::Configuration,
-    default_api::{self, CreateAppParams, DescribeAppParams},
+use tower_api::{
+    apis::{
+        configuration::Configuration,
+        default_api::{self, CreateAppParams, DescribeAppParams},
+    },
+    models::CreateAppParams as CreateAppParamsModel,
 };
-use tower_api::models::CreateAppParams as CreateAppParamsModel;
+
+use crate::output;
 
 pub async fn ensure_app_exists(
     api_config: &Configuration,

--- a/crates/tower-cmd/src/util/apps.rs
+++ b/crates/tower-cmd/src/util/apps.rs
@@ -53,14 +53,15 @@ pub async fn ensure_app_exists(
     }
 
     // Decide whether to create the app
-    let create_app = auto_create || prompt_default(
-        format!(
-            "App '{}' does not exist. Would you like to create it?",
-            app_name
-        ),
-        false,
-    )
-    .unwrap_or(false);
+    let create_app = auto_create
+        || prompt_default(
+            format!(
+                "App '{}' does not exist. Would you like to create it?",
+                app_name
+            ),
+            false,
+        )
+        .unwrap_or(false);
 
     // If the user doesn't want to create the app, return the original error
     if !create_app {

--- a/crates/tower-cmd/src/util/cmd.rs
+++ b/crates/tower-cmd/src/util/cmd.rs
@@ -1,5 +1,6 @@
-use crate::output;
 use clap::ArgMatches;
+
+use crate::output;
 
 pub fn get_string_flag(args: &ArgMatches, name: &str) -> String {
     args.get_one::<String>(name)

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -1,17 +1,19 @@
-use crate::{output, util};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
 use reqwest::{Body, Client as ReqwestClient, Method};
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
+use tower_api::{
+    apis::{configuration::Configuration, default_api::DeployAppError, Error, ResponseContent},
+    models::DeployAppResponse,
+};
 use tower_package::{compute_sha256_file, Package};
 use tower_telemetry::debug;
 
-use tower_api::apis::configuration::Configuration;
-use tower_api::apis::default_api::DeployAppError;
-use tower_api::apis::Error;
-use tower_api::apis::ResponseContent;
-use tower_api::models::DeployAppResponse;
+use crate::{output, util};
 
 pub async fn upload_file_with_progress(
     api_config: &Configuration,

--- a/crates/tower-cmd/src/util/progress.rs
+++ b/crates/tower-cmd/src/util/progress.rs
@@ -1,9 +1,10 @@
-use futures_util::stream::Stream;
-use std::sync::{Arc, Mutex};
 use std::{
     pin::Pin,
+    sync::{Arc, Mutex},
     task::{Context, Poll},
 };
+
+use futures_util::stream::Stream;
 
 pub struct ProgressStream<R> {
     inner: R,

--- a/crates/tower-cmd/src/version.rs
+++ b/crates/tower-cmd/src/version.rs
@@ -1,5 +1,6 @@
-use crate::output;
 use clap::Command;
+
+use crate::output;
 
 pub fn version_cmd() -> Command {
     Command::new("version").about("Print the current version of Tower")

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -71,7 +71,10 @@ async fn test_running_hello_world() {
     }
 
     let found_hello = outputs.iter().any(|line| line.contains("Hello, world!"));
-    assert!(found_hello, "Should have received 'Hello, world!' output from the application");
+    assert!(
+        found_hello,
+        "Should have received 'Hello, world!' output from the application"
+    );
 
     // check the status once more, should be done.
     let status = app.status().await.expect("Failed to get app status");

--- a/tests/integration/features/cli_runs.feature
+++ b/tests/integration/features/cli_runs.feature
@@ -16,7 +16,7 @@ Feature: CLI Run Commands
     And the final status should show "Your app crashed!" in red
 
   Scenario: CLI remote run should show detailed validation errors
-    Given I have a simple hello world application
+    Given I have a test app for CLI validation
     When I run "tower run -p nonexistent_param=test" via CLI
     Then the output should show "API Error:"
     And the output should show "Validation error"
@@ -24,7 +24,7 @@ Feature: CLI Run Commands
     And the output should not just show "422"
 
   Scenario: CLI run should show spinners during execution
-    Given I have a simple hello world application
+    Given I have a test app for CLI validation
     When I run "tower run" via CLI
     Then the output should show "Scheduling run..." spinner
     And the output should show "Waiting for run to start..." spinner

--- a/tests/integration/features/cli_runs.feature
+++ b/tests/integration/features/cli_runs.feature
@@ -6,7 +6,7 @@ Feature: CLI Run Commands
   Scenario: CLI remote run should show red error message when API fails
     Given I have a simple hello world application
     When I run "tower run" via CLI
-    Then the final crash status should show red "Oh no!"
+    Then the final crash status should show red "Error:"
 
   Scenario: CLI local run should have green timestamps and detect crashes
     Given I have a simple hello world application that exits with code 1

--- a/tests/integration/features/cli_runs.feature
+++ b/tests/integration/features/cli_runs.feature
@@ -3,18 +3,13 @@ Feature: CLI Run Commands
   I want to run applications locally and remotely with proper feedback
   So that I can develop and deploy my applications effectively
 
-  Background:
-    Given I have a Tower CLI binary available
-
-  Scenario: CLI remote run should have yellow timestamps and proper formatting
+  Scenario: CLI remote run should show red error message when API fails
     Given I have a simple hello world application
     When I run "tower run" via CLI
-    Then timestamps should be yellow colored
-    And each log line should be on a separate line
-    And the final crash status should show red "Oh no!"
+    Then the final crash status should show red "Oh no!"
 
   Scenario: CLI local run should have green timestamps and detect crashes
-    Given I have a simple hello world application that exits with code 1  
+    Given I have a simple hello world application that exits with code 1
     When I run "tower run --local" via CLI
     Then timestamps should be green colored
     And each log line should be on a separate line
@@ -23,7 +18,7 @@ Feature: CLI Run Commands
   Scenario: CLI remote run should show detailed validation errors
     Given I have a simple hello world application
     When I run "tower run -p nonexistent_param=test" via CLI
-    Then the output should show "Error details:"
+    Then the output should show "API Error:"
     And the output should show "Validation error"
     And the output should show "Unknown parameter"
     And the output should not just show "422"

--- a/tests/integration/features/cli_runs.feature
+++ b/tests/integration/features/cli_runs.feature
@@ -1,0 +1,36 @@
+Feature: CLI Run Commands
+  As a developer using Tower CLI directly
+  I want to run applications locally and remotely with proper feedback
+  So that I can develop and deploy my applications effectively
+
+  Background:
+    Given I have a Tower CLI binary available
+
+  Scenario: CLI remote run should have yellow timestamps and proper formatting
+    Given I have a simple hello world application
+    When I run "tower run" via CLI
+    Then timestamps should be yellow colored
+    And each log line should be on a separate line
+    And the final crash status should show red "Oh no!"
+
+  Scenario: CLI local run should have green timestamps and detect crashes
+    Given I have a simple hello world application that exits with code 1  
+    When I run "tower run --local" via CLI
+    Then timestamps should be green colored
+    And each log line should be on a separate line
+    And the final status should show "Your app crashed!" in red
+
+  Scenario: CLI remote run should show detailed validation errors
+    Given I have a simple hello world application
+    When I run "tower run -p nonexistent_param=test" via CLI
+    Then the output should show "Error details:"
+    And the output should show "Validation error"
+    And the output should show "Unknown parameter"
+    And the output should not just show "422"
+
+  Scenario: CLI run should show spinners during execution
+    Given I have a simple hello world application
+    When I run "tower run" via CLI
+    Then the output should show "Scheduling run..." spinner
+    And the output should show "Waiting for run to start..." spinner
+    And both spinners should complete successfully

--- a/tests/integration/features/environment.py
+++ b/tests/integration/features/environment.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 def before_all(context):
-    context.tower_url = os.environ.get("TOWER_API_URL")
+    context.tower_url = os.environ.get("TOWER_API_URL", "http://127.0.0.1:8000")
     print(f"TOWER_API_URL: {context.tower_url}")
 
 
@@ -21,6 +21,9 @@ def before_scenario(context, scenario):
     tower_binary = _find_tower_binary()
     if not tower_binary:
         raise RuntimeError("Could not find tower binary. Run 'cargo build' first.")
+
+    # Make binary available to all steps
+    context.tower_binary = tower_binary
 
     # Set up environment
     test_env = os.environ.copy()

--- a/tests/integration/features/mcp_app_management.feature
+++ b/tests/integration/features/mcp_app_management.feature
@@ -45,6 +45,13 @@ Feature: MCP App Management
     Then I should receive an error response about app not deployed
     And the MCP server should remain responsive
 
+  Scenario: Remote run succeeds after proper deployment
+    Given I have a simple hello world application
+    When I call tower_deploy via MCP
+    Then I should receive a success response about deployment
+    When I call tower_run_remote via MCP
+    Then I should receive a response about the run
+
   Scenario: Test timeout mechanism with guaranteed slow application
     Given I have a long-running application
     When I call tower_run_local via MCP

--- a/tests/integration/features/mcp_app_management.feature
+++ b/tests/integration/features/mcp_app_management.feature
@@ -98,4 +98,4 @@ Feature: MCP App Management
     Given I have a simple hello world application that exits with code 1
     When I call tower_run_local via MCP
     Then the response should indicate the app crashed
-    And the response should contain "ERROR:" or "crashed" message
+    And the response should contain "failed" message

--- a/tests/integration/features/mcp_app_management.feature
+++ b/tests/integration/features/mcp_app_management.feature
@@ -80,9 +80,9 @@ Feature: MCP App Management
     When I call tower_schedules_delete with the schedule ID
     Then I should receive a success response about schedule deletion
 
-  Scenario: MCP remote run output should be plain text without color codes
+  Scenario: MCP local run output should be plain text without color codes
     Given I have a simple hello world application
-    When I call tower_run_remote via MCP
+    When I call tower_run_local via MCP
     Then the response should contain plain text log lines
     And the response should not contain ANSI color codes
     And each log line should be properly formatted with timestamp

--- a/tests/integration/features/mcp_app_management.feature
+++ b/tests/integration/features/mcp_app_management.feature
@@ -106,3 +106,9 @@ Feature: MCP App Management
     When I call tower_run_local via MCP
     Then the response should indicate the app crashed
     And the response should contain "failed" message
+
+  Scenario: Deploy auto-creates app when it doesn't exist
+    Given I have a simple hello world application
+    When I call tower_deploy via MCP
+    Then I should receive a success response about deployment
+    And the app "hello-world" should be visible in Tower

--- a/tests/integration/features/mcp_app_management.feature
+++ b/tests/integration/features/mcp_app_management.feature
@@ -79,3 +79,23 @@ Feature: MCP App Management
     Given I have created a schedule for "test-app"
     When I call tower_schedules_delete with the schedule ID
     Then I should receive a success response about schedule deletion
+
+  Scenario: MCP remote run output should be plain text without color codes
+    Given I have a simple hello world application
+    When I call tower_run_remote via MCP
+    Then the response should contain plain text log lines
+    And the response should not contain ANSI color codes
+    And each log line should be properly formatted with timestamp
+
+  Scenario: MCP remote run should show detailed validation errors
+    Given I have a simple hello world application
+    When I call tower_run_remote with invalid parameter "nonexistent_param=test"
+    Then I should receive a detailed validation error
+    And the error should mention "Unknown parameter"
+    And the error should not just be a status code
+
+  Scenario: Local run should detect exit code failures
+    Given I have a simple hello world application that exits with code 1
+    When I call tower_run_local via MCP
+    Then the response should indicate the app crashed
+    And the response should contain "ERROR:" or "crashed" message

--- a/tests/integration/features/steps/cli_steps.py
+++ b/tests/integration/features/steps/cli_steps.py
@@ -87,13 +87,13 @@ def step_log_lines_should_be_separate(context):
     ), f"Expected multiple timestamped lines, got: {timestamp_lines}"
 
 
-@then('the final crash status should show red "Oh no!"')
-def step_final_crash_status_should_be_red(context):
-    """Verify crash status shows red 'Oh no!' message"""
+@then('the final crash status should show red "Error:"')
+def step_final_crash_status_should_show_error(context):
+    """Verify crash status shows red 'Error:' message"""
     output = context.cli_output
     # Red is ANSI code 31
     assert "\x1b[31m" in output, f"Expected red color codes in output"
-    assert "Oh no!" in output, f"Expected 'Oh no!' in crash message, got: {output}"
+    assert "Error:" in output, f"Expected 'Error:' in crash message, got: {output}"
 
 
 @then('the final status should show "Your app crashed!" in red')

--- a/tests/integration/features/steps/cli_steps.py
+++ b/tests/integration/features/steps/cli_steps.py
@@ -7,6 +7,7 @@ import shutil
 from pathlib import Path
 from behave import given, when, then
 
+
 @when('I run "{command}" via CLI')
 def step_run_cli_command(context, command):
     """Run a Tower CLI command and capture output"""
@@ -146,5 +147,3 @@ def step_both_spinners_should_complete(context):
     assert (
         found_completion
     ), f"Expected spinner completion indicators in output, got: {output[:500]}..."
-
-

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -618,3 +618,18 @@ def step_response_should_contain_message(context, expected_text):
     assert (
         expected_text.lower() in response_content
     ), f"Expected '{expected_text}' in response, got: {context.mcp_response}"
+
+
+@then("I should receive a success response about deployment")
+def step_success_response_about_deployment(context):
+    """Verify the response indicates successful deployment"""
+    assert context.operation_success, f"Deploy operation should succeed, got: {context.mcp_response}"
+
+    response_content = str(context.mcp_response.get("content", "")).lower()
+    deployment_keywords = ["deploy", "version", "tower"]
+    found_deployment_success = any(
+        keyword in response_content for keyword in deployment_keywords
+    )
+    assert (
+        found_deployment_success
+    ), f"Response should mention deployment success, got: {context.mcp_response}"

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -49,6 +49,7 @@ def create_towerfile(app_type="hello_world"):
     """Create a Towerfile for testing - pure function with no side effects beyond file creation"""
     configs = {
         "hello_world": ("hello-world", "hello.py", "Simple hello world app"),
+        "test_app": ("test-app", "hello.py", "Pre-existing test app for CLI tests"),
         "long_running": (
             "long-runner",
             "long_runner.py",
@@ -121,6 +122,11 @@ def step_create_valid_towerfile(context):
 @given("I have a simple hello world application")
 def step_create_hello_world_app(context):
     create_towerfile("hello_world")
+
+
+@given("I have a test app for CLI validation")
+def step_create_test_app_for_cli(context):
+    create_towerfile("test_app")
 
 
 @given("I have a long-running application")
@@ -613,7 +619,9 @@ def step_response_should_contain_message(context, expected_text):
 @then("I should receive a success response about deployment")
 def step_success_response_about_deployment(context):
     """Verify the response indicates successful deployment"""
-    assert context.operation_success, f"Deploy operation should succeed, got: {context.mcp_response}"
+    assert (
+        context.operation_success
+    ), f"Deploy operation should succeed, got: {context.mcp_response}"
 
     response_content = str(context.mcp_response.get("content", "")).lower()
     deployment_keywords = ["deploy", "version", "tower"]
@@ -630,4 +638,6 @@ def step_success_response_about_deployment(context):
 async def step_app_should_be_visible_in_tower(context, app_name):
     """Verify that the specified app is now visible in Tower"""
     result = await call_mcp_tool(context, "tower_apps_show", {"name": app_name})
-    assert result.get("success", False), f"App '{app_name}' should be visible in Tower, but tower_apps_show failed: {result}"
+    assert result.get(
+        "success", False
+    ), f"App '{app_name}' should be visible in Tower, but tower_apps_show failed: {result}"

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -524,7 +524,7 @@ def step_each_log_line_should_be_formatted_with_timestamp(context):
     response_content = str(context.mcp_response.get("content", ""))
 
     # Split into lines and check timestamp format
-    lines = [line.strip() for line in response_content.split('\n') if line.strip()]
+    lines = [line.strip() for line in response_content.split("\n") if line.strip()]
 
     # Find lines that contain the pipe separator (these should be log lines)
     log_lines = [line for line in lines if " | " in line]

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -103,10 +103,12 @@ def is_error_response(response):
 def step_have_running_mcp_server(context):
     # This step is handled by the before_scenario hook in environment.py
     # Just verify the MCP server was set up properly
-    assert hasattr(context, "tower_process"), "Tower process should be set up"
+    assert hasattr(
+        context, "tower_mcpserver_process"
+    ), "Tower mcp server process should be set up"
     assert hasattr(context, "mcp_server_url"), "MCP server URL should be set up"
 
-    server_alive = context.tower_process.poll() is None
+    server_alive = context.tower_mcpserver_process.poll() is None
     print(f"DEBUG: MCP server alive check: {server_alive}")
     assert server_alive, "MCP server should be running"
 
@@ -311,7 +313,7 @@ async def step_check_server_responsive(context):
     """Verify the MCP server is still responsive after the operation."""
     try:
         # Check if process is alive and server responds
-        if context.tower_process.poll() is not None:
+        if context.tower_mcpserver_process.poll() is not None:
             print("Warning: MCP server process died")
             context.server_responsive = False
         else:

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -468,18 +468,8 @@ async def step_app_exists_in_tower(context, app_name):
 @given('the app "{app_name}" exists and is deployed in Tower')
 @async_run_until_complete
 async def step_app_exists_and_deployed_in_tower(context, app_name):
-    """Ensure the specified app exists and is marked as deployed in Tower"""
-    import httpx
-    import os
-
-    # Create the app using the MCP server
-    result = await call_mcp_tool(context, "tower_apps_create", {"name": app_name})
-
-    # Deploy the app by calling the mock API directly
-    api_url = os.environ.get("TOWER_API_URL", "http://127.0.0.1:8000")
-    async with httpx.AsyncClient() as client:
-        deploy_response = await client.post(f"{api_url}/v1/apps/{app_name}/deploy")
-        # We don't need to check the response - the mock will handle it
+    """Ensure the specified app exists and is deployed in Tower"""
+    result = await call_mcp_tool(context, "tower_deploy", {})
 
 
 @when('I call tower_run_remote with invalid parameter "{param}"')
@@ -633,3 +623,11 @@ def step_success_response_about_deployment(context):
     assert (
         found_deployment_success
     ), f"Response should mention deployment success, got: {context.mcp_response}"
+
+
+@then('the app "{app_name}" should be visible in Tower')
+@async_run_until_complete
+async def step_app_should_be_visible_in_tower(context, app_name):
+    """Verify that the specified app is now visible in Tower"""
+    result = await call_mcp_tool(context, "tower_apps_show", {"name": app_name})
+    assert result.get("success", False), f"App '{app_name}' should be visible in Tower, but tower_apps_show failed: {result}"

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -451,3 +451,139 @@ def step_check_schedule_deletion_success(context):
     assert (
         "deleted" in str(context.mcp_response).lower()
     ), f"Response should mention deletion, got: {context.mcp_response}"
+
+
+@when('I call tower_run_remote with invalid parameter "{param}"')
+@async_run_until_complete
+async def step_call_tower_run_remote_with_invalid_param(context, param):
+    """Call tower_run_remote with an invalid parameter"""
+    key, value = param.split("=", 1)
+    arguments = {"parameters": {key: value}}
+    await call_mcp_tool(context, "tower_run_remote", arguments)
+
+
+@then("the response should contain plain text log lines")
+def step_response_should_contain_plain_text_log_lines(context):
+    """Verify response contains properly formatted plain text log lines"""
+    response_content = str(context.mcp_response.get("content", ""))
+    assert (
+        response_content
+    ), f"Response should have content, got: {context.mcp_response}"
+
+    # Check for timestamp formatting (should have | separator for plain text)
+    assert (
+        " | " in response_content
+    ), f"Expected plain text format with '|' separator, got: {response_content[:200]}..."
+
+
+@then("the response should not contain ANSI color codes")
+def step_response_should_not_contain_ansi_codes(context):
+    """Verify response doesn't contain ANSI color escape sequences"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Check for common ANSI color codes
+    ansi_patterns = ["\033[", "\x1b[", "[0m", "[1;33m", "[31m"]
+    for pattern in ansi_patterns:
+        assert (
+            pattern not in response_content
+        ), f"Found ANSI color code '{pattern}' in response: {response_content[:200]}..."
+
+
+@then("each log line should be properly formatted with timestamp")
+def step_log_lines_should_be_formatted_with_timestamp(context):
+    """Verify log lines have proper timestamp formatting"""
+    response_content = str(context.mcp_response.get("content", ""))
+    lines = response_content.split("\n")
+
+    # Find lines that look like log entries (contain timestamp patterns)
+    log_lines = [line for line in lines if " | " in line and "2025-" in line]
+    assert (
+        len(log_lines) > 0
+    ), f"Expected to find log lines with timestamps, got: {response_content[:300]}..."
+
+    # Check timestamp format (should be YYYY-MM-DD HH:MM:SS | message)
+    for line in log_lines[:3]:  # Check first few log lines
+        parts = line.split(" | ", 1)
+        assert (
+            len(parts) == 2
+        ), f"Log line should have timestamp | message format, got: {line}"
+        timestamp, message = parts
+        assert (
+            len(timestamp.strip()) >= 19
+        ), f"Timestamp should be at least YYYY-MM-DD HH:MM:SS, got: {timestamp}"
+
+
+@then("I should receive a detailed validation error")
+def step_should_receive_detailed_validation_error(context):
+    """Verify response contains detailed validation error information"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Should be an error but with detailed content, not just a status code
+    assert (
+        not context.operation_success
+    ), f"Expected error response, got success: {context.mcp_response}"
+    assert (
+        len(response_content) > 10
+    ), f"Expected detailed error message, got short response: {response_content}"
+
+
+@then('the error should mention "{expected_text}"')
+def step_error_should_mention_text(context, expected_text):
+    """Verify error message contains specific expected text"""
+    response_content = str(context.mcp_response.get("content", ""))
+    assert (
+        expected_text.lower() in response_content.lower()
+    ), f"Expected '{expected_text}' in error response, got: {response_content}"
+
+
+@then("the error should not just be a status code")
+def step_error_should_not_be_just_status_code(context):
+    """Verify error is not just a bare status code like '422'"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Should not be just a number (status code)
+    assert (
+        not response_content.strip().isdigit()
+    ), f"Error should not be just a status code, got: {response_content}"
+    assert (
+        "422" not in response_content or len(response_content) > 20
+    ), f"Should have detailed error, not just '422', got: {response_content}"
+
+
+@given("I have a simple hello world application that exits with code 1")
+def step_have_hello_world_app_with_exit_1(context):
+    """Create a hello world app that exits with code 1 for crash testing"""
+    create_towerfile("hello_world")
+
+    # Create a Python file that exits with code 1
+    crash_app_content = """import time
+print("Hello, World!")
+time.sleep(1)
+print("About to crash...")
+exit(1)
+"""
+    with open("task.py", "w") as f:
+        f.write(crash_app_content)
+
+
+@then("the response should indicate the app crashed")
+def step_response_should_indicate_crash(context):
+    """Verify response indicates the application crashed"""
+    response_content = str(context.mcp_response.get("content", "")).lower()
+
+    crash_indicators = ["crash", "error", "failed", "exit"]
+    found_indicator = any(
+        indicator in response_content for indicator in crash_indicators
+    )
+    assert (
+        found_indicator
+    ), f"Expected crash indication in response, got: {context.mcp_response}"
+
+
+@then('the response should contain "{expected_text}" message')
+def step_response_should_contain_message(context, expected_text):
+    """Verify response contains expected message text"""
+    response_content = str(context.mcp_response.get("content", "")).lower()
+    assert (
+        expected_text.lower() in response_content
+    ), f"Expected '{expected_text}' in response, got: {context.mcp_response}"

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -562,7 +562,7 @@ time.sleep(1)
 print("About to crash...")
 exit(1)
 """
-    with open("task.py", "w") as f:
+    with open("hello.py", "w") as f:
         f.write(crash_app_content)
 
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -99,9 +99,23 @@ def main():
     # Actually run tests
     try:
         test_dir = Path(__file__).parent / "features"
-        log("Running integration tests...")
+
+        args = sys.argv[1:]
+
+        # Enable parallel execution by default unless single test is specified
+        single_test_mode = any(arg.startswith("-n") or arg in ["-n"] for arg in args)
+
+        # defaulting to 2 workers if user doesn't override
+        if not single_test_mode and "--jobs" not in " ".join(args) and "-j" not in args:
+            args = ["--jobs", "2"] + args
+            log("Running tests in parallel (2 workers)")
+        elif single_test_mode:
+            log("Running single test (no parallelization)")
+        else:
+            log("Running integration tests...")
+
         result = subprocess.run(
-            ["behave", str(test_dir)] + sys.argv[1:], cwd=Path(__file__).parent, env=env
+            ["behave", str(test_dir)] + args, cwd=Path(__file__).parent, env=env
         )
         return result.returncode
 

--- a/tests/mock-api-server/README.md
+++ b/tests/mock-api-server/README.md
@@ -76,7 +76,7 @@ If the `User` model gains a new required field `department: String`, update the 
 After updating the mock API:
 
 1. Restart the mock server: `cd tests/mock-api-server && ./run.sh`
-2. Run the integration tests: `cd tests/integration && TOWER_MOCK_API_URL=http://127.0.0.1:8000 uv run behave features/`
+2. Run the integration tests: `cd tests/integration && TOWER_API_URL=http://127.0.0.1:8000 uv run behave features/`
 3. Ensure all tests pass
 
 ## Files to Update

--- a/tests/mock-api-server/README.md
+++ b/tests/mock-api-server/README.md
@@ -47,8 +47,7 @@ The mock API is returning JSON that doesn't match the Rust structs generated fro
 
 4. **Run a single test with debug output**:
    ```bash
-   cd tests/integration
-   TOWER_API_URL=http://127.0.0.1:8000 uv run behave features/mcp_app_management.feature -n "Run simple application successfully locally" --no-capture
+   TOWER_API_URL=http://127.0.0.1:8000 ./tests/integration/run_tests.py -n "Run simple application successfully locally"
    ```
 
 ### Updating the Mock API
@@ -75,8 +74,8 @@ If the `User` model gains a new required field `department: String`, update the 
 
 After updating the mock API:
 
-1. Restart the mock server: `cd tests/mock-api-server && ./run.sh`
-2. Run the integration tests: `cd tests/integration && TOWER_API_URL=http://127.0.0.1:8000 uv run behave features/`
+1. Restart the mock server: `tests/mock-api-server/run.sh`
+2. In another shell, run the integration tests: `./tests/integration/run_tests.py`
 3. Ensure all tests pass
 
 ## Files to Update

--- a/tests/mock-api-server/main.py
+++ b/tests/mock-api-server/main.py
@@ -423,7 +423,10 @@ async def stream_run_logs(name: str, seq: int):
         mock_logs = [
             {"timestamp": "2025-08-22T12:00:00Z", "content": "Starting application..."},
             {"timestamp": "2025-08-22T12:00:01Z", "content": "Hello, World!"},
-            {"timestamp": "2025-08-22T12:00:02Z", "content": "Application completed successfully"},
+            {
+                "timestamp": "2025-08-22T12:00:02Z",
+                "content": "Application completed successfully",
+            },
         ]
 
         for log_entry in mock_logs:
@@ -432,8 +435,8 @@ async def stream_run_logs(name: str, seq: int):
                 "event_type": "log",
                 "data": {
                     "reported_at": log_entry["timestamp"],
-                    "content": log_entry["content"]
-                }
+                    "content": log_entry["content"],
+                },
             }
             yield f"data: {json.dumps(log_data)}\n\n"
             await asyncio.sleep(0.1)  # Small delay between logs
@@ -444,7 +447,7 @@ async def stream_run_logs(name: str, seq: int):
     return StreamingResponse(
         generate_log_stream(),
         media_type="text/plain",
-        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
     )
 
 

--- a/tests/mock-api-server/main.py
+++ b/tests/mock-api-server/main.py
@@ -145,6 +145,16 @@ async def run_app(name: str, run_params: Dict[str, Any]):
     if name not in mock_apps_db:
         raise HTTPException(status_code=404, detail=f"App '{name}' not found")
 
+    parameters = run_params.get("parameters", {})
+    if "nonexistent_param" in parameters:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "detail": "Validation error",
+                "errors": [{"message": "Unknown parameter"}],
+            },
+        )
+
     run_id = generate_id()
     new_run = {
         "$link": f"/runs/{run_id}",


### PR DESCRIPTION
The MCP server resulted in a bunch of regression for running an app via the actual CLI — this was because I refactored it to have a pure inner function and a side-effectful outer function, and re-used the inner function in both the MCP server and in the CLI. I tried to keep most of the functionality by using a ChannelSink at the time, with the idea that we could still stream logs in. However, fundamentally the behaviour needs to be different.

So:
- remote runs have newlines again (😅)
- there's two different sinks now, `ChannelSink` for the normal formatted lines, and `PlainChannelSink` for no formatting (for MCP server responses)
- 422 errors were not being successfully interpreted as errors by the MCP server, and fundamentally it seemed to be because the `unwrap_api_response` from the api.rs didn't treat them as errors (which they're not really — they're 4xx issues). I'm not 100% sure this solution is the best and am interested in other suggestions

  However we want to be able to see we've passed in the wrong parameters to a run, and the MCP server should accordingly return with an error when this fails, so now we wrap the call to `unwrap_api_response` with a check to see if there was a client error or server error — and when there is, return an actual Err response that we can match for in the sink logic (see [here](https://github.com/tower/tower-cli/compare/develop...fix/cli-run-regressions?expand=1#diff-7d1ee340d973bf920db1c89e6bf40a06603127b382cc4bf345558b9fe528f4dbR217) and [here](https://github.com/tower/tower-cli/compare/develop...fix/cli-run-regressions?expand=1#diff-7d1ee340d973bf920db1c89e6bf40a06603127b382cc4bf345558b9fe528f4dbR245))
- reintroduce spinners (and pass in a boolean to enable or disable them so as not to spam the MCP server)
- timestamps are colourized again
- the lines appear one by one. Not sure exactly why that was broken before, maybe the fact it was all on one line they got buffered
- local runs correctly detect when the app errored out locally (this got subtly broke in the refactor, `status_task.abort();` got called before we printed out the failure)
- lots of regression tests so this won't happen again (and of course, the tests caught a bunch of ways my fixes weren't working 🙃)