### PR TITLE
fix: improve deploy error handling and propagation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,35 +2,26 @@ name: Integration Tests
 
 on:
   pull_request:
-    branches:
-      - '*'
-  push:
-    branches:
-      - '*'
-    tags-ignore:
-      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v6
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
-    - name: "Set up Python"
-      uses: actions/setup-python@v5
-      with:
-        python-version-file: ".python-version"
+      - name: Install Python dependencies
+        run: uv sync --locked --group test
 
-    - name: Build Tower CLI
-      run: cargo build
-
-    - name: Install Python dependencies
-      run: uv sync --locked --group dev
-
-    - name: Run integration tests
-      run: tests/integration/run_tests.py
+      - name: Run integration tests
+        run: tests/integration/run_tests.py --format progress3 --color always

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -7,11 +7,6 @@ name: "[tower] Test python"
 
 on:
   pull_request:
-  push:
-    branches:
-      - '*'
-    tags-ignore:
-      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -7,11 +7,6 @@ name: "[tower] Test rust"
 
 on:
   pull_request:
-  push:
-    branches:
-      - '*'
-    tags-ignore:
-      - '**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/config/src/towerfile.rs
+++ b/crates/config/src/towerfile.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct Parameter{
+pub struct Parameter {
     #[serde(default)]
     pub name: String,
 
@@ -115,7 +115,6 @@ impl Towerfile {
         std::fs::write(target_path, toml::to_string_pretty(self)?)?;
         Ok(())
     }
-
 
     /// add_parameter adds a new parameter to the Towerfile
     pub fn add_parameter(&mut self, name: String, description: String, default: String) {
@@ -277,19 +276,18 @@ mod test {
     fn test_add_parameter() {
         let mut towerfile = crate::Towerfile::default();
         assert_eq!(towerfile.parameters.len(), 0);
-        
+
         towerfile.add_parameter(
             "test-param".to_string(),
             "A test parameter".to_string(),
-            "default-value".to_string()
+            "default-value".to_string(),
         );
-        
+
         assert_eq!(towerfile.parameters.len(), 1);
         assert_eq!(towerfile.parameters[0].name, "test-param");
         assert_eq!(towerfile.parameters[0].description, "A test parameter");
         assert_eq!(towerfile.parameters[0].default, "default-value");
     }
-
 
     #[test]
     fn test_roundtrip_serialization() {
@@ -310,11 +308,11 @@ name = "param2"
 description = "Second parameter"
 default = "value2"
 "#;
-        
+
         let towerfile = crate::Towerfile::from_toml(original_toml).unwrap();
         let serialized = toml::to_string_pretty(&towerfile).unwrap();
         let reparsed = crate::Towerfile::from_toml(&serialized).unwrap();
-        
+
         assert_eq!(towerfile.app.name, reparsed.app.name);
         assert_eq!(towerfile.app.script, reparsed.app.script);
         assert_eq!(towerfile.app.source, reparsed.app.source);

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -29,61 +29,66 @@ fn resolve_path(args: &ArgMatches) -> PathBuf {
 }
 
 pub async fn do_deploy(config: Config, args: &ArgMatches) {
-    // Determine the directory to build the package from
     let dir = resolve_path(args);
-    debug!("Building package from directory: {:?}", dir);
-
-    let path = dir.join("Towerfile");
-
-    match Towerfile::from_path(path) {
-        Ok(towerfile) => {
-            let api_config = config.into();
-
-            // Add app existence check before proceeding
-            if let Err(err) = util::apps::ensure_app_exists(
-                &api_config,
-                &towerfile.app.name,
-                &towerfile.app.description,
-            )
-            .await
-            {
-                output::tower_error(err);
-                return;
-            }
-
-            let spec = PackageSpec::from_towerfile(&towerfile);
-            let mut spinner = output::spinner("Building package...");
-
-            match Package::build(spec).await {
-                Ok(package) => {
-                    spinner.success();
-                    do_deploy_package(api_config, package, &towerfile).await;
-                }
-                Err(err) => {
-                    spinner.failure();
-                    output::package_error(err);
-                }
-            }
-        }
-        Err(err) => {
-            output::config_error(err);
+    if let Err(err) = deploy_from_dir(config, dir).await {
+        match err {
+            crate::Error::ApiDeployError { source } => output::tower_error(source),
+            crate::Error::ApiDescribeAppError { source } => output::tower_error(source),
+            _ => eprintln!("Deploy error: {}", err),
         }
     }
 }
 
-async fn do_deploy_package(api_config: Configuration, package: Package, towerfile: &Towerfile) {
+pub async fn deploy_from_dir(
+    config: Config,
+    dir: PathBuf,
+) -> Result<(), crate::Error> {
+    debug!("Building package from directory: {:?}", dir);
+
+    let path = dir.join("Towerfile");
+
+    let towerfile = Towerfile::from_path(path)?;
+    let api_config = config.into();
+
+    // Add app existence check before proceeding
+    util::apps::ensure_app_exists(
+        &api_config,
+        &towerfile.app.name,
+        &towerfile.app.description,
+    )
+    .await?;
+
+    let spec = PackageSpec::from_towerfile(&towerfile);
+    let mut spinner = output::spinner("Building package...");
+
+    let package = match Package::build(spec).await {
+        Ok(package) => package,
+        Err(err) => {
+            spinner.failure();
+            let error = crate::Error::PackageError { source: err };
+            eprintln!("Package build failed: {}", error);
+            return Err(error);
+        }
+    };
+
+    spinner.success();
+    do_deploy_package(api_config, package, &towerfile).await
+}
+
+async fn do_deploy_package(
+    api_config: Configuration,
+    package: Package,
+    towerfile: &Towerfile,
+) -> Result<(), crate::Error> {
     let res = util::deploy::deploy_app_package(&api_config, &towerfile.app.name, package).await;
 
     match res {
         Ok(resp) => {
             let version = resp.version;
-
             let line = format!("Version `{}` has been deployed to Tower!", version.version);
-
             output::success(&line);
+            Ok(())
         }
-        Err(err) => {
-            output::tower_error(err);
-        }
+        Err(err) => Err(crate::Error::ApiDeployError { source: err }),
     }
 }

--- a/crates/tower-cmd/src/environments.rs
+++ b/crates/tower-cmd/src/environments.rs
@@ -36,9 +36,7 @@ pub async fn do_list(config: Config) {
             let envs_data: Vec<Vec<String>> = resp
                 .environments
                 .into_iter()
-                .map(|env| {
-                    vec![env.name]
-                })
+                .map(|env| vec![env.name])
                 .collect();
 
             // Display the table using the existing table function

--- a/crates/tower-cmd/src/error.rs
+++ b/crates/tower-cmd/src/error.rs
@@ -1,5 +1,7 @@
 use snafu::prelude::*;
-use tower_api::apis::default_api::{DescribeRunError, RunAppError};
+use tower_api::apis::default_api::{
+    DeployAppError, DescribeAppError, DescribeRunError, RunAppError,
+};
 use tower_telemetry::debug;
 
 #[derive(Debug, Snafu)]
@@ -35,6 +37,12 @@ pub enum Error {
 
     #[snafu(display("Run was cancelled"))]
     RunCancelled,
+
+    #[snafu(display("App crashed during local execution"))]
+    AppCrashed,
+
+    #[snafu(display("API error occurred"))]
+    ApiError,
 
     #[snafu(display("Failed to load Towerfile from {}: {}", path, source))]
     TowerfileLoadFailed { path: String, source: config::Error },
@@ -75,6 +83,18 @@ pub enum Error {
     #[snafu(display("API run error: {}", source))]
     ApiRunError {
         source: tower_api::apis::Error<RunAppError>,
+    },
+
+    // API deploy error
+    #[snafu(display("API deploy error: {}", source))]
+    ApiDeployError {
+        source: tower_api::apis::Error<DeployAppError>,
+    },
+
+    // API describe app error
+    #[snafu(display("API describe app error: {}", source))]
+    ApiDescribeAppError {
+        source: tower_api::apis::Error<DescribeAppError>,
     },
 
     // Channel error
@@ -144,6 +164,18 @@ impl From<tower_package::Error> for Error {
 impl From<tower_api::apis::Error<RunAppError>> for Error {
     fn from(source: tower_api::apis::Error<RunAppError>) -> Self {
         Self::ApiRunError { source }
+    }
+}
+
+impl From<tower_api::apis::Error<DeployAppError>> for Error {
+    fn from(source: tower_api::apis::Error<DeployAppError>) -> Self {
+        Self::ApiDeployError { source }
+    }
+}
+
+impl From<tower_api::apis::Error<DescribeAppError>> for Error {
+    fn from(source: tower_api::apis::Error<DescribeAppError>) -> Self {
+        Self::ApiDescribeAppError { source }
     }
 }
 

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -6,8 +6,9 @@ mod apps;
 mod deploy;
 mod environments;
 pub mod error;
-mod package;
+mod mcp;
 pub mod output;
+mod package;
 mod run;
 mod schedules;
 mod secrets;
@@ -16,7 +17,6 @@ mod teams;
 mod towerfile_gen;
 mod util;
 mod version;
-mod mcp;
 
 pub use error::Error;
 
@@ -165,10 +165,12 @@ impl App {
                     }
                 }
             }
-            Some(("mcp-server", args)) => mcp::do_mcp_server(sessionized_config, args).await.unwrap_or_else(|e| {
-                eprintln!("MCP server error: {}", e);
-                std::process::exit(1);
-            }),
+            Some(("mcp-server", args)) => mcp::do_mcp_server(sessionized_config, args)
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("MCP server error: {}", e);
+                    std::process::exit(1);
+                }),
             _ => {
                 cmd_clone.print_help().unwrap();
                 std::process::exit(2);

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -404,7 +404,7 @@ impl TowerService {
     async fn tower_deploy(&self) -> Result<CallToolResult, McpError> {
         use std::path::PathBuf;
 
-        match deploy::deploy_from_dir(self.config.clone(), PathBuf::from(".")).await {
+        match deploy::deploy_from_dir(self.config.clone(), PathBuf::from("."), true).await {
             Ok(_) => Self::text_success("Deploy completed successfully".to_string()),
             Err(e) => Self::error_result("Deploy failed", e),
         }

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -402,9 +402,12 @@ impl TowerService {
         description = "Deploy your app to Tower cloud. Prerequisites: 1) Create Towerfile, 2) Create app with tower_apps_create"
     )]
     async fn tower_deploy(&self) -> Result<CallToolResult, McpError> {
-        let matches = clap::ArgMatches::default();
-        deploy::do_deploy(self.config.clone(), &matches).await;
-        Self::text_success("Deploy command completed - check output above for status".to_string())
+        use std::path::PathBuf;
+
+        match deploy::deploy_from_dir(self.config.clone(), PathBuf::from(".")).await {
+            Ok(_) => Self::text_success("Deploy completed successfully".to_string()),
+            Err(e) => Self::error_result("Deploy failed", e),
+        }
     }
 
     #[tool(

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -5,10 +5,10 @@ use cli_table::{
 };
 use colored::Colorize;
 use http::StatusCode;
+use regex::Regex;
 use std::io::{self, Write};
 use std::sync::{Mutex, OnceLock};
 use tokio::sync::mpsc::UnboundedSender;
-use regex::Regex;
 use tower_api::{
     apis::{Error as ApiError, ResponseContent},
     models::ErrorModel,
@@ -22,6 +22,10 @@ static CURRENT_SENDER: Mutex<Option<UnboundedSender<String>>> = Mutex::new(None)
 
 pub fn set_capture_mode() {
     CAPTURE_MODE.set(true).ok();
+}
+
+pub fn is_capture_mode_set() -> bool {
+    CAPTURE_MODE.get().is_some()
 }
 
 pub fn set_current_sender(sender: UnboundedSender<String>) {

--- a/crates/tower-cmd/src/package.rs
+++ b/crates/tower-cmd/src/package.rs
@@ -30,7 +30,10 @@ pub fn package_cmd() -> Command {
 
 pub async fn do_package(_config: Config, args: &ArgMatches) {
     // Determine the directory to build the package from
-    let dir = PathBuf::from(args.get_one::<String>("dir").expect("dir argument should have default value"));
+    let dir = PathBuf::from(
+        args.get_one::<String>("dir")
+            .expect("dir argument should have default value"),
+    );
     debug!("Building package from directory: {:?}", dir);
 
     let path = dir.join("Towerfile");
@@ -43,14 +46,19 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
             match Package::build(spec).await {
                 Ok(package) => {
                     spinner.success();
-                    
+
                     // Get the output path
-                    let output_path = args.get_one::<String>("output").expect("output path is required");
-                    
+                    let output_path = args
+                        .get_one::<String>("output")
+                        .expect("output path is required");
+
                     // Save the package
                     match save_package(&package, output_path).await {
                         Ok(_) => {
-                            output::success(&format!("Package created successfully: {}", output_path));
+                            output::success(&format!(
+                                "Package created successfully: {}",
+                                output_path
+                            ));
                         }
                         Err(err) => {
                             output::error(&format!("Failed to save package: {}", err));
@@ -69,19 +77,24 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
     }
 }
 
-async fn save_package(package: &Package, output_path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let package_path = package.package_file_path.as_ref()
+async fn save_package(
+    package: &Package,
+    output_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let package_path = package
+        .package_file_path
+        .as_ref()
         .ok_or("No package file path found")?;
-    
+
     let output_path = PathBuf::from(output_path);
-    
+
     // Create parent directories if they don't exist
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent).await?;
     }
-    
+
     // Copy the package file to the specified location
     fs::copy(package_path, &output_path).await?;
-    
+
     Ok(())
 }

--- a/crates/tower-cmd/src/towerfile_gen.rs
+++ b/crates/tower-cmd/src/towerfile_gen.rs
@@ -180,12 +180,10 @@ name = "custom-script-project"
         let result =
             TowerfileGenerator::from_pyproject(Some("/nonexistent/path/pyproject.toml"), None);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("pyproject.toml not found")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("pyproject.toml not found"));
     }
 
     #[test]
@@ -205,12 +203,10 @@ requires = ["setuptools"]
         let result =
             TowerfileGenerator::from_pyproject(Some(pyproject_path.to_str().unwrap()), None);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("No [project] section found")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No [project] section found"));
     }
 
     #[test]

--- a/crates/tower-cmd/src/util/apps.rs
+++ b/crates/tower-cmd/src/util/apps.rs
@@ -11,6 +11,7 @@ pub async fn ensure_app_exists(
     api_config: &Configuration,
     app_name: &str,
     description: &str,
+    auto_create: bool,
 ) -> Result<(), tower_api::apis::Error<default_api::DescribeAppError>> {
     // Try to describe the app first
     let describe_result = default_api::describe_app(
@@ -48,15 +49,16 @@ pub async fn ensure_app_exists(
         return Err(err);
     }
 
-    // Prompt the user to create the app
-    let create_app = prompt_default(
-        format!(
-            "App '{}' does not exist. Would you like to create it?",
-            app_name
-        ),
-        false,
-    )
-    .unwrap_or(false);
+    // Decide whether to create the app
+    let create_app = auto_create
+        || prompt_default(
+            format!(
+                "App '{}' does not exist. Would you like to create it?",
+                app_name
+            ),
+            false,
+        )
+        .unwrap_or(false);
 
     // If the user doesn't want to create the app, return the original error
     if !create_app {

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -71,7 +71,10 @@ async fn test_running_hello_world() {
     }
 
     let found_hello = outputs.iter().any(|line| line.contains("Hello, world!"));
-    assert!(found_hello, "Should have received 'Hello, world!' output from the application");
+    assert!(
+        found_hello,
+        "Should have received 'Hello, world!' output from the application"
+    );
 
     // check the status once more, should be done.
     let status = app.status().await.expect("Failed to get app status");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,16 +93,19 @@ extend-exclude = '''
 '''
 
 [dependency-groups]
-dev = [
+test = [
   "aiohttp==3.10.11",
   "behave==1.3.3",
-  "black==24.10.0",
   "mcp>=1.1.0; python_version>='3.10'",
-  "openapi-python-client==0.24.3",
-  "pre-commit==4.0.1",
   "pytest==8.3.5",
   "pytest-httpx==0.35.0",
   "pytest-env>=1.1.3",
+]
+dev = [
+  { include-group = "test" },
+  "black==24.10.0",
+  "openapi-python-client==0.24.3",
+  "pre-commit==4.0.1",
   "pyiceberg[sql-sqlite]==0.9.1",
   "tower[iceberg]",
 ]

--- a/tests/integration/features/cli_runs.feature
+++ b/tests/integration/features/cli_runs.feature
@@ -1,0 +1,33 @@
+Feature: CLI Run Commands
+  As a developer using Tower CLI directly
+  I want to run applications locally and remotely with proper feedback
+  So that I can develop and deploy my applications effectively
+
+  Scenario: CLI remote run should show red error message when API fails
+    Given I have a simple hello world application
+    When I run "tower run" via CLI
+    Then the final crash status should show red "Error:"
+
+  Scenario: CLI local run should have green timestamps and detect crashes
+    Given I have a simple hello world application that exits with code 1
+    When I run "tower run --local" via CLI
+    Then timestamps should be green colored
+    And each log line should be on a separate line
+    And the final status should show "Your app crashed!" in red
+
+  Scenario: CLI remote run should show detailed validation errors
+    Given I have a valid Towerfile in the current directory
+    When I run "tower deploy --auto-create" via CLI
+    Then I run "tower run -p nonexistent_param=test" via CLI
+    Then the output should show "API Error:"
+    And the output should show "Validation error"
+    And the output should show "Unknown parameter"
+    And the output should not just show "422"
+
+  Scenario: CLI run should show spinners during execution
+    Given I have a valid Towerfile in the current directory
+    When I run "tower deploy --auto-create" via CLI
+    And I run "tower run" via CLI
+    Then the output should show "Scheduling run..." spinner
+    And the output should show "Waiting for run to start..." spinner
+    And both spinners should complete successfully

--- a/tests/integration/features/environment.py
+++ b/tests/integration/features/environment.py
@@ -3,12 +3,89 @@ import subprocess
 import time
 import tempfile
 import socket
+import threading
+import queue
 from pathlib import Path
 
 
 def before_all(context):
-    context.tower_url = os.environ.get("TOWER_API_URL")
+    context.tower_url = os.environ.get("TOWER_API_URL", "http://127.0.0.1:8000")
     print(f"TOWER_API_URL: {context.tower_url}")
+
+    tower_binary = _find_tower_binary()
+    if not tower_binary:
+        raise RuntimeError("Could not find tower binary. Run 'cargo build' first.")
+
+    context.tower_binary = tower_binary
+
+    test_env = os.environ.copy()
+    test_env["TOWER_RUN_TIMEOUT"] = "3"
+    if context.tower_url:
+        test_env["TOWER_URL"] = context.tower_url
+        test_env["TOWER_JWT"] = "mock_jwt_token"
+
+    # Start MCP server (maybe should somehow be limited to mcp features in the future?)
+    mcp_port = _find_free_port()
+    context.tower_mcpserver_process = subprocess.Popen(
+        [tower_binary, "mcp-server", "--port", str(mcp_port)],
+        env=test_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # Set up continuous log capture to avoid accumulation
+    context.mcp_stdout_queue = queue.Queue()
+    context.mcp_stderr_queue = queue.Queue()
+
+    def drain_mcp_stream(stream, output_queue, stream_name):
+        try:
+            for line in iter(stream.readline, ""):
+                output_queue.put(
+                    f"[MCP-{stream_name}] [{time.strftime('%H:%M:%S')}] {line.rstrip()}"
+                )
+        except:
+            pass
+
+    context.stdout_thread = threading.Thread(
+        target=drain_mcp_stream,
+        args=(
+            context.tower_mcpserver_process.stdout,
+            context.mcp_stdout_queue,
+            "STDOUT",
+        ),
+        daemon=True,
+    )
+    context.stderr_thread = threading.Thread(
+        target=drain_mcp_stream,
+        args=(
+            context.tower_mcpserver_process.stderr,
+            context.mcp_stderr_queue,
+            "STDERR",
+        ),
+        daemon=True,
+    )
+    context.stdout_thread.start()
+    context.stderr_thread.start()
+
+    # Give server time to start
+    time.sleep(2)
+
+    # Check if process is still running
+    if context.tower_mcpserver_process.poll() is not None:
+        # Collect any startup errors
+        startup_errors = []
+        while not context.mcp_stderr_queue.empty():
+            startup_errors.append(context.mcp_stderr_queue.get_nowait())
+        if startup_errors:
+            print(
+                f"DEBUG: Shared MCP server startup errors:\n{chr(10).join(startup_errors)}"
+            )
+        raise RuntimeError(
+            f"Shared MCP server exited with code {context.tower_mcpserver_process.returncode}"
+        )
+
+    context.mcp_server_url = f"http://127.0.0.1:{mcp_port}"
 
 
 def before_scenario(context, scenario):
@@ -17,54 +94,31 @@ def before_scenario(context, scenario):
     context.original_cwd = os.getcwd()
     os.chdir(context.temp_dir)
 
-    # Start tower mcp-server synchronously
-    tower_binary = _find_tower_binary()
-    if not tower_binary:
-        raise RuntimeError("Could not find tower binary. Run 'cargo build' first.")
 
-    # Set up environment
-    test_env = os.environ.copy()
-    test_env["TOWER_RUN_TIMEOUT"] = "3"
-
-    if context.tower_url:
-        test_env["TOWER_URL"] = context.tower_url
-        test_env["TOWER_JWT"] = "mock_jwt_token"
-
-    # Find a free port for this test scenario
-    mcp_port = _find_free_port()
-
-    # Start the server process
-    context.tower_process = subprocess.Popen(
-        [tower_binary, "mcp-server", "--port", str(mcp_port)],
-        env=test_env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
-
-    # Give server time to start
-    time.sleep(2)
-
-    # Check if process is still running
-    if context.tower_process.poll() is not None:
-        stderr_output = context.tower_process.stderr.read()
-        if stderr_output:
-            print(f"DEBUG: MCP server stderr: {stderr_output}")
-        raise RuntimeError(
-            f"MCP server exited with code {context.tower_process.returncode}"
-        )
-
-    context.mcp_server_url = f"http://127.0.0.1:{mcp_port}"
+def _flush_queue(q):
+    """Flush all items from a queue and return as list."""
+    items = []
+    while True:
+        try:
+            items.append(q.get_nowait())
+        except queue.Empty:
+            break
+    return items
 
 
 def after_scenario(context, scenario):
-    if hasattr(context, "tower_process") and context.tower_process:
-        try:
-            context.tower_process.terminate()
-            context.tower_process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            context.tower_process.kill()
-            context.tower_process.wait()
+    # Show MCP output for failed tests by flushing the queues
+    if hasattr(context, "mcp_stderr_queue") and hasattr(context, "mcp_stdout_queue"):
+        if scenario.status.name in ["failed", "error"] or os.environ.get(
+            "DEBUG_MCP_SERVER"
+        ):
+            stdout_lines = _flush_queue(context.mcp_stdout_queue)
+            stderr_lines = _flush_queue(context.mcp_stderr_queue)
+
+            if stdout_lines or stderr_lines:
+                print(f"\n=== MCP Server Output ===")
+                for line in stdout_lines + stderr_lines:
+                    print(line)
 
     # Clean up temp directory
     if hasattr(context, "original_cwd"):
@@ -76,7 +130,14 @@ def after_scenario(context, scenario):
 
 
 def after_all(context):
-    pass
+    # Clean up shared MCP server
+    if hasattr(context, "tower_mcpserver_process") and context.tower_mcpserver_process:
+        try:
+            context.tower_mcpserver_process.terminate()
+            context.tower_mcpserver_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            context.tower_mcpserver_process.kill()
+            context.tower_mcpserver_process.wait()
 
 
 def _find_free_port():

--- a/tests/integration/features/steps/cli_steps.py
+++ b/tests/integration/features/steps/cli_steps.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import subprocess
+import os
+import tempfile
+import shutil
+from pathlib import Path
+from behave import given, when, then
+
+
+@step('I run "{command}" via CLI')
+def step_run_cli_command(context, command):
+    """Run a Tower CLI command and capture output"""
+    cli_path = context.tower_binary
+
+    # Run the CLI command in the current directory (where environment.py set up the temp dir)
+    # The MCP steps have already created the necessary files in the current directory
+
+    # Run the CLI command
+    cmd_parts = command.split()
+    full_command = [cli_path] + cmd_parts[1:]  # Skip 'tower' prefix
+
+    try:
+        # Force colored output by setting environment variables
+        test_env = os.environ.copy()
+        test_env["FORCE_COLOR"] = "1"  # Force colored output
+        test_env["CLICOLOR_FORCE"] = "1"  # Force colored output
+        test_env["TOWER_URL"] = context.tower_url  # Use mock API
+        test_env["TOWER_JWT"] = "mock_jwt_token"
+
+        result = subprocess.run(
+            full_command,
+            capture_output=True,
+            text=True,
+            timeout=60,  # 1 minute timeout
+            env=test_env,
+        )
+        context.cli_output = result.stdout + result.stderr
+        context.cli_return_code = result.returncode
+    except subprocess.TimeoutExpired:
+        context.cli_output = "Command timed out"
+        context.cli_return_code = 124
+    except Exception as e:
+        print(f"DEBUG: Exception in CLI command: {type(e).__name__}: {e}")
+        print(f"DEBUG: Command was: {full_command}")
+        print(f"DEBUG: Working directory: {os.getcwd()}")
+        raise
+
+
+@step("timestamps should be yellow colored")
+def step_timestamps_should_be_yellow(context):
+    """Verify timestamps are colored yellow (ANSI code 33)"""
+    output = context.cli_output
+    # Yellow is ANSI code 33, bold yellow is 1;33
+    assert (
+        "\x1b[1;33m" in output or "\x1b[33m" in output
+    ), f"Expected yellow color codes in output, got: {output[:300]}..."
+
+
+@step("timestamps should be green colored")
+def step_timestamps_should_be_green(context):
+    """Verify timestamps are colored green (ANSI code 32)"""
+    output = context.cli_output
+    # Green is ANSI code 32, bold green is 1;32
+    assert (
+        "\x1b[1;32m" in output or "\x1b[32m" in output
+    ), f"Expected green color codes in output, got: {output[:300]}..."
+
+
+@step("each log line should be on a separate line")
+def step_log_lines_should_be_separate(context):
+    """Verify log lines are properly separated with newlines"""
+    output = context.cli_output
+    lines = output.split("\n")
+
+    # Should have multiple lines
+    assert len(lines) > 3, f"Expected multiple lines of output, got: {len(lines)} lines"
+
+    # Lines with timestamps should not be concatenated
+    timestamp_lines = [
+        line
+        for line in lines
+        if "2025-" in line and ("Hello" in line or "Creating" in line)
+    ]
+    assert (
+        len(timestamp_lines) > 1
+    ), f"Expected multiple timestamped lines, got: {timestamp_lines}"
+
+
+red_color_code = "\x1b[31m"
+
+
+@step('the final crash status should show red "Error:"')
+def step_final_crash_status_should_show_error(context):
+    """Verify crash status shows red 'Error:' message"""
+    output = context.cli_output
+    # Red is ANSI code 31
+    assert (
+        red_color_code in output
+    ), f"Expected red color codes in output, got: {output}"
+    assert "Error:" in output, f"Expected 'Error:' in crash message, got: {output}"
+
+
+@step('the final status should show "Your app crashed!" in red')
+def step_final_status_should_show_crashed_in_red(context):
+    """Verify local run shows 'Your app crashed!' in red"""
+    output = context.cli_output
+    assert (
+        red_color_code in output
+    ), f"Expected red color codes in output, got: {output}"
+    assert (
+        "Your app crashed!" in output
+    ), f"Expected 'Your app crashed!' message, got: {output}"
+
+
+@step('the output should show "{expected_text}"')
+def step_output_should_show_text(context, expected_text):
+    """Verify output contains expected text"""
+    output = context.cli_output
+    assert (
+        expected_text in output
+    ), f"Expected '{expected_text}' in output, got: {output}"
+
+
+@step('the output should not just show "{forbidden_text}"')
+def step_output_should_not_just_show_text(context, forbidden_text):
+    """Verify output is not just the forbidden text (e.g., not just '422')"""
+    output = context.cli_output.strip()
+    assert (
+        output != forbidden_text
+    ), f"Output should not be just '{forbidden_text}', got: {output}"
+    if forbidden_text in output:
+        assert (
+            len(output) > len(forbidden_text) + 10
+        ), f"Output should have more than just '{forbidden_text}', got: {output}"
+
+
+@step('the output should show "{spinner_text}" spinner')
+def step_output_should_show_spinner(context, spinner_text):
+    """Verify spinner text appears in output"""
+    output = context.cli_output
+    assert (
+        spinner_text in output
+    ), f"Expected spinner text '{spinner_text}' in output, got: {output[:500]}..."
+
+
+@step("both spinners should complete successfully")
+def step_both_spinners_should_complete(context):
+    """Verify spinners show completion"""
+    output = context.cli_output
+    # Look for spinner completion indicators (✔ or "Done!")
+    completion_indicators = ["✔", "Done!", "success"]
+    found_completion = any(indicator in output for indicator in completion_indicators)
+    assert (
+        found_completion
+    ), f"Expected spinner completion indicators in output, got: {output[:500]}..."

--- a/tests/integration/features/steps/mcp_steps.py
+++ b/tests/integration/features/steps/mcp_steps.py
@@ -6,6 +6,7 @@ from behave import given, when, then
 from behave.api.async_step import async_run_until_complete
 from mcp import ClientSession
 from mcp.client.sse import sse_client
+import uuid
 
 
 async def call_mcp_tool_raw(
@@ -16,14 +17,22 @@ async def call_mcp_tool_raw(
     if working_directory:
         args["working_directory"] = working_directory
 
+    captured_logs = []
+
+    async def logging_callback(params):
+        captured_logs.append(params)
+
     async with sse_client(f"{server_url}/sse") as (read, write):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read, write, logging_callback=logging_callback
+        ) as session:
             await session.initialize()
             result = await session.call_tool(tool_name, args)
             return {
                 "success": not result.isError,
                 "content": result.content,
                 "result": result,
+                "captured_logs": captured_logs,
             }
 
 
@@ -45,14 +54,21 @@ async def call_mcp_tool(context, tool_name, arguments=None):
         return context.mcp_response
 
 
-def create_towerfile(app_type="hello_world"):
-    """Create a Towerfile for testing - pure function with no side effects beyond file creation"""
-    configs = {
-        "hello_world": ("hello-world", "hello.py", "Simple hello world app"),
-    }
+def unique_app_name(context, name="hello-world", force_new=False):
+    if force_new:
+        context.unique_suffix = str(uuid.uuid4())
+    suffix = getattr(context, "unique_suffix", "")
+    return f"{name}-{context.unique_suffix}"
 
-    app_name, script_name, description = configs.get(app_type, configs["hello_world"])
-    template_dir = Path(__file__).parent.parent.parent / "templates"
+
+def create_towerfile(
+    context, app_name="hello-world", script_name="hello.py", description="A test app"
+):
+    """Create a Towerfile for testing - pure function with no side effects beyond file creation"""
+
+    app_name = unique_app_name(context, app_name, force_new=True)
+
+    template_dir = Path(__file__).parents[2] / "templates"
 
     # Create Towerfile from template if it exists
     towerfile_template = template_dir / "Towerfile.j2"
@@ -98,22 +114,24 @@ def is_error_response(response):
 def step_have_running_mcp_server(context):
     # This step is handled by the before_scenario hook in environment.py
     # Just verify the MCP server was set up properly
-    assert hasattr(context, "tower_process"), "Tower process should be set up"
+    assert hasattr(
+        context, "tower_mcpserver_process"
+    ), "Tower MCP server process should be set up"
     assert hasattr(context, "mcp_server_url"), "MCP server URL should be set up"
 
-    server_alive = context.tower_process.poll() is None
+    server_alive = context.tower_mcpserver_process.poll() is None
     print(f"DEBUG: MCP server alive check: {server_alive}")
     assert server_alive, "MCP server should be running"
 
 
 @given("I have a valid Towerfile in the current directory")
 def step_create_valid_towerfile(context):
-    create_towerfile("hello_world")
+    create_towerfile(context)
 
 
 @given("I have a simple hello world application")
 def step_create_hello_world_app(context):
-    create_towerfile("hello_world")
+    create_towerfile(context)
 
 
 @given("I have a pyproject.toml file with project metadata")
@@ -132,24 +150,26 @@ version = "0.1.0"
         f.write('print("Hello from test project")\n')
 
 
-@when("I call {tool_name} via MCP")
+@step("I call {tool_name} via MCP")
 @async_run_until_complete
 async def step_call_mcp_tool(context, tool_name):
     await call_mcp_tool(context, tool_name)
 
 
-@when('I call {tool_name} with app name "{app_name}"')
+@step('I call {tool_name} with new app name "{app_name}"')
 @async_run_until_complete
-async def step_call_mcp_tool_with_app_name(context, tool_name, app_name):
-    await call_mcp_tool(context, tool_name, {"name": app_name})
+async def step_call_mcp_tool_with_unique_app_name(context, tool_name, app_name):
+    await call_mcp_tool(
+        context, tool_name, {"name": unique_app_name(context, app_name, force_new=True)}
+    )
 
 
-@then("I should receive a response")
+@step("I should receive a response")
 def step_check_response_exists(context):
     assert hasattr(context, "mcp_response") and context.mcp_response is not None
 
 
-@then("I should receive a response with apps data")
+@step("I should receive a response with apps data")
 def step_check_apps_data_response(context):
     assert context.mcp_response.get("content"), "Response should have content"
     found_apps_data = has_text_content(
@@ -160,14 +180,14 @@ def step_check_apps_data_response(context):
     ), f"Response should contain apps data, got: {context.mcp_response.get('content')}"
 
 
-@then("I should receive an error response")
+@step("I should receive an error response")
 def step_check_error_response(context):
     assert is_error_response(
         context.mcp_response
     ), f"Expected error response, got: {context.mcp_response}"
 
 
-@then("I should receive an error response about missing Towerfile")
+@step("I should receive an error response about missing Towerfile")
 def step_check_missing_towerfile_error(context):
     response_text = str(context.mcp_response).lower()
     assert (
@@ -175,14 +195,14 @@ def step_check_missing_towerfile_error(context):
     ), f"Error should mention Towerfile, got: {context.mcp_response}"
 
 
-@then("I should receive a success response")
+@step("I should receive a success response")
 def step_check_success_response(context):
     assert context.mcp_response.get(
         "success", False
     ), f"Expected success response, got: {context.mcp_response}"
 
 
-@then("I should receive the parsed Towerfile configuration")
+@step("I should receive the parsed Towerfile configuration")
 def step_check_parsed_towerfile(context):
     """Verify the response contains parsed Towerfile data."""
     assert context.mcp_response.get("content"), "Response should have content"
@@ -195,7 +215,7 @@ def step_check_parsed_towerfile(context):
     ), f"Response should contain Towerfile config, got: {context.mcp_response.get('content')}"
 
 
-@then("I should receive a response about the run")
+@step("I should receive a response about the run")
 def step_check_run_response(context):
     """Verify the response is about running the application."""
     assert hasattr(context, "mcp_response"), "No MCP response was recorded"
@@ -220,7 +240,7 @@ def step_check_run_response(context):
     ), f"Expected successful run response, got: {context.mcp_response}"
 
 
-@then("I should receive an error response about app not deployed")
+@step("I should receive an error response about app not deployed")
 def step_check_app_not_deployed_error(context):
     """Verify the error mentions app not being deployed."""
     assert hasattr(context, "mcp_response"), "No MCP response was recorded"
@@ -236,7 +256,7 @@ def step_check_app_not_deployed_error(context):
     ), f"Error should mention deployment, got: {context.mcp_response}"
 
 
-@then("I should receive a valid TOML Towerfile")
+@step("I should receive a valid TOML Towerfile")
 def step_check_valid_toml_towerfile(context):
     """Verify the response contains valid TOML Towerfile content."""
     assert hasattr(context, "mcp_response"), "No MCP response was recorded"
@@ -258,7 +278,7 @@ def step_check_valid_toml_towerfile(context):
     ), f"Response should contain valid TOML Towerfile, got: {response_content}"
 
 
-@then("the Towerfile should contain the project name and description")
+@step("the Towerfile should contain the project name and description")
 def step_check_towerfile_metadata(context):
     """Verify the Towerfile contains expected project metadata."""
     assert hasattr(context, "mcp_response"), "No MCP response was recorded"
@@ -281,13 +301,13 @@ def step_check_towerfile_metadata(context):
     ), f"Towerfile should contain project name and description, got: {response_content}"
 
 
-@then("the MCP server should remain responsive")
+@step("the MCP server should remain responsive")
 @async_run_until_complete
 async def step_check_server_responsive(context):
     """Verify the MCP server is still responsive after the operation."""
     try:
         # Check if process is alive and server responds
-        if context.tower_process.poll() is not None:
+        if context.tower_mcpserver_process.poll() is not None:
             print("Warning: MCP server process died")
             context.server_responsive = False
         else:
@@ -307,14 +327,18 @@ async def step_check_server_responsive(context):
 
 
 # Schedule-related steps
-@given('I have created a schedule for "{app_name}"')
+@given('I have created a schedule for "predeployed-test-app"')
 @async_run_until_complete
-async def step_create_schedule_for_app(context, app_name):
+async def step_create_schedule_for_app(context):
     """Create a schedule for testing purposes."""
     result = await call_mcp_tool(
         context,
         "tower_schedules_create",
-        {"app_name": app_name, "cron": "0 9 * * *", "environment": "default"},
+        {
+            "app_name": "predeployed-test-app",
+            "cron": "0 9 * * *",
+            "environment": "default",
+        },
     )
     assert result.get("success", False), f"Failed to create schedule: {result}"
 
@@ -330,26 +354,25 @@ async def step_create_schedule_for_app(context, app_name):
             if match:
                 context.created_schedule_id = match.group(1)
 
-    context.test_app_name = app_name
 
-
-@when(
-    'I call tower_schedules_create with app "{app_name}", cron "{cron}", and environment "{environment}"'
+@step(
+    'I call tower_schedules_create with app "predeployed-test-app", cron "{cron}", and environment "{environment}"'
 )
 @async_run_until_complete
-async def step_call_schedules_create(context, app_name, cron, environment):
+async def step_call_schedules_create(context, cron, environment):
     """Call tower_schedules_create with specific parameters."""
     await call_mcp_tool(
         context,
         "tower_schedules_create",
-        {"app_name": app_name, "cron": cron, "environment": environment},
+        {
+            "app_name": "predeployed-test-app",
+            "cron": cron,
+            "environment": environment,
+        },
     )
-    context.test_app_name = app_name
-    context.test_cron = cron
-    context.test_environment = environment
 
 
-@when('I call tower_schedules_update with new cron "{new_cron}"')
+@step('I call tower_schedules_update with new cron "{new_cron}"')
 @async_run_until_complete
 async def step_call_schedules_update(context, new_cron):
     """Call tower_schedules_update with new cron expression."""
@@ -362,7 +385,7 @@ async def step_call_schedules_update(context, new_cron):
     context.updated_cron = new_cron
 
 
-@when("I call tower_schedules_delete with the schedule ID")
+@step("I call tower_schedules_delete with the schedule ID")
 @async_run_until_complete
 async def step_call_schedules_delete(context):
     """Call tower_schedules_delete with a schedule ID."""
@@ -370,7 +393,7 @@ async def step_call_schedules_delete(context):
     await call_mcp_tool(context, "tower_schedules_delete", {"name": schedule_id})
 
 
-@then("I should receive a response with empty schedules data")
+@step("I should receive a response with empty schedules data")
 def step_check_empty_schedules_response(context):
     """Verify the response contains empty schedules list."""
     assert context.mcp_response.get("content"), "Response should have content"
@@ -383,7 +406,7 @@ def step_check_empty_schedules_response(context):
     ), f"Response should contain empty schedules data, got: {context.mcp_response.get('content')}"
 
 
-@then("I should receive a success response about schedule creation")
+@step("I should receive a success response about schedule creation")
 def step_check_schedule_creation_success(context):
     """Verify the response indicates successful schedule creation."""
     assert context.mcp_response.get(
@@ -394,20 +417,20 @@ def step_check_schedule_creation_success(context):
     ), f"Response should mention creation, got: {context.mcp_response}"
 
 
-@then('I should receive a response with schedule data for "{app_name}"')
-def step_check_schedules_list_with_data(context, app_name):
+@step('I should receive a response with schedule data for "predeployed-test-app"')
+def step_check_schedules_list_with_data(context):
     """Verify the response contains schedule data for the specified app."""
     assert context.mcp_response.get("content"), "Response should have content"
     found_schedule_data = has_text_content(
         context.mcp_response,
-        lambda text: "schedules" in text.lower() and app_name in text,
+        lambda text: "schedules" in text.lower() and "predeployed-test-app" in text,
     )
     assert (
         found_schedule_data
-    ), f"Response should contain schedule data for '{app_name}', got: {context.mcp_response.get('content')}"
+    ), f"Response should contain schedule data for 'predeployed-test-app', got: {context.mcp_response.get('content')}"
 
 
-@then("I should receive a success response about schedule update")
+@step("I should receive a success response about schedule update")
 def step_check_schedule_update_success(context):
     """Verify the response indicates successful schedule update."""
     assert context.mcp_response.get(
@@ -418,7 +441,7 @@ def step_check_schedule_update_success(context):
     ), f"Response should mention update, got: {context.mcp_response}"
 
 
-@then("I should receive a success response about schedule deletion")
+@step("I should receive a success response about schedule deletion")
 def step_check_schedule_deletion_success(context):
     """Verify the response indicates successful schedule deletion."""
     assert context.mcp_response.get(
@@ -427,3 +450,194 @@ def step_check_schedule_deletion_success(context):
     assert (
         "deleted" in str(context.mcp_response).lower()
     ), f"Response should mention deletion, got: {context.mcp_response}"
+
+
+@step('I call tower_run_remote with invalid parameter "{param}"')
+@async_run_until_complete
+async def step_call_tower_run_remote_with_invalid_param(context, param):
+    """Call tower_run_remote with an invalid parameter"""
+    key, value = param.split("=", 1)
+    arguments = {"parameters": {key: value}}
+    await call_mcp_tool(context, "tower_run_remote", arguments)
+
+
+@step("the response should contain plain text log lines")
+def step_response_should_contain_plain_text_log_lines(context):
+    """Verify response contains properly formatted plain text log lines"""
+    response_content = str(context.mcp_response.get("content", ""))
+    assert (
+        response_content
+    ), f"Response should have content, got: {context.mcp_response}"
+
+    # Check for timestamp formatting (should have | separator for plain text)
+    assert (
+        " | " in response_content
+    ), f"Expected plain text format with '|' separator, got: {response_content[:200]}..."
+
+
+@step("the response should not contain ANSI color codes")
+def step_response_should_not_contain_ansi_codes(context):
+    """Verify response doesn't contain ANSI color escape sequences"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Check for common ANSI color codes
+    ansi_patterns = ["\033[", "\x1b[", "[0m", "[1;33m", "[31m"]
+    for pattern in ansi_patterns:
+        assert (
+            pattern not in response_content
+        ), f"Found ANSI color code '{pattern}' in response: {response_content[:200]}..."
+
+
+@step("each log line should be properly formatted with timestamp")
+def step_each_log_line_should_be_formatted_with_timestamp(context):
+    """Verify each log line has proper timestamp format"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Split into lines and check timestamp format
+    lines = [line.strip() for line in response_content.split("\n") if line.strip()]
+
+    # Find lines that contain the pipe separator (these should be log lines)
+    log_lines = [line for line in lines if " | " in line]
+    assert (
+        len(log_lines) > 0
+    ), f"Expected to find log lines with '|' separator, got: {response_content[:300]}..."
+
+    # Check timestamp format for a few log lines
+    for line in log_lines[:3]:  # Check first few log lines
+        parts = line.split(" | ", 1)
+        assert (
+            len(parts) == 2
+        ), f"Log line should have 'timestamp | message' format, got: {line}"
+        timestamp, message = parts
+        assert (
+            len(timestamp.strip()) >= 10
+        ), f"Timestamp should be substantial, got: '{timestamp}'"
+
+
+@step("I should receive a detailed validation error")
+def step_should_receive_detailed_validation_error(context):
+    """Verify response contains detailed validation error information"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Should be an error but with detailed content, not just a status code
+    assert (
+        not context.operation_success
+    ), f"Expected error response, got success: {context.mcp_response}"
+    assert (
+        len(response_content) > 10
+    ), f"Expected detailed error message, got short response: {response_content}"
+
+
+@step('the error should mention "{expected_text}"')
+def step_error_should_mention_text(context, expected_text):
+    """Verify error message contains specific expected text"""
+    response_content = str(context.mcp_response.get("content", ""))
+    assert (
+        expected_text.lower() in response_content.lower()
+    ), f"Expected '{expected_text}' in error response, got: {response_content}"
+
+
+@step("the error should not just be a status code")
+def step_error_should_not_be_just_status_code(context):
+    """Verify error is not just a bare status code like '422'"""
+    response_content = str(context.mcp_response.get("content", ""))
+
+    # Should not be just a number (status code)
+    assert (
+        not response_content.strip().isdigit()
+    ), f"Error should not be just a status code, got: {response_content}"
+    assert (
+        "422" not in response_content or len(response_content) > 20
+    ), f"Should have detailed error, not just '422', got: {response_content}"
+
+
+@given("I have a simple hello world application that exits with code 1")
+def step_have_hello_world_app_with_exit_1(context):
+    """Create a hello world app that exits with code 1 for crash testing"""
+    create_towerfile(context)
+
+    # Create a Python file that exits with code 1
+    crash_app_content = """import time
+print("Hello, World!")
+time.sleep(1)
+print("About to crash...")
+exit(1)
+"""
+    with open("hello.py", "w") as f:
+        f.write(crash_app_content)
+
+
+@step("the response should indicate the app crashed")
+def step_response_should_indicate_crash(context):
+    """Verify response indicates the application crashed"""
+    response_content = str(context.mcp_response.get("content", "")).lower()
+
+    crash_indicators = ["crash", "error", "failed", "exit"]
+    found_indicator = any(
+        indicator in response_content for indicator in crash_indicators
+    )
+    assert (
+        found_indicator
+    ), f"Expected crash indication in response, got: {context.mcp_response}"
+
+
+@step('the response should contain "{expected_text}" message')
+def step_response_should_contain_message(context, expected_text):
+    """Verify response contains expected message text"""
+    response_content = str(context.mcp_response.get("content", "")).lower()
+    assert (
+        expected_text.lower() in response_content
+    ), f"Expected '{expected_text}' in response, got: {context.mcp_response}"
+
+
+@step("I should receive a success response about deployment")
+def step_success_response_about_deployment(context):
+    """Verify the response indicates successful deployment"""
+    assert (
+        context.operation_success
+    ), f"Deploy operation should succeed, got: {context.mcp_response}"
+
+    response_content = str(context.mcp_response.get("content", "")).lower()
+    deployment_keywords = ["deploy", "version", "tower"]
+    found_deployment_success = any(
+        keyword in response_content for keyword in deployment_keywords
+    )
+    assert (
+        found_deployment_success
+    ), f"Response should mention deployment success, got: {context.mcp_response}"
+
+
+@step('the app "{app_name}" should be visible in Tower')
+@async_run_until_complete
+async def step_app_should_be_visible_in_tower(context, app_name):
+    """Verify that the specified app is now visible in Tower"""
+    app_name = unique_app_name(context, app_name)
+    result = await call_mcp_tool(context, "tower_apps_show", {"name": app_name})
+    assert result.get(
+        "success", False
+    ), f"App '{app_name}' should be visible in Tower, but tower_apps_show failed: {result}"
+
+
+@step("I should receive logging notifications")
+def step_should_receive_logging_notifications(context):
+    """Verify that logging notifications were captured"""
+    logs = context.mcp_response.get("captured_logs", [])
+    assert len(logs) > 0, "Expected logging notifications but got none"
+
+
+@step("the logs should contain process output")
+def step_logs_should_contain_output(context):
+    """Verify logs contain actual process messages"""
+    logs = context.mcp_response.get("captured_logs", [])
+    assert any(
+        log.data.get("message", "").strip() for log in logs
+    ), "No process output in logs"
+
+
+@step("the logs should have tower-process logger")
+def step_logs_should_have_correct_logger(context):
+    """Verify logs use the correct logger name"""
+    logs = context.mcp_response.get("captured_logs", [])
+    assert any(
+        log.logger == "tower-process" for log in logs
+    ), "Missing tower-process logger"

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -99,9 +99,23 @@ def main():
     # Actually run tests
     try:
         test_dir = Path(__file__).parent / "features"
-        log("Running integration tests...")
+
+        args = sys.argv[1:]
+
+        # Enable parallel execution by default unless single test is specified
+        single_test_mode = any(arg.startswith("-n") or arg in ["-n"] for arg in args)
+
+        # defaulting to 2 workers if user doesn't override
+        if not single_test_mode and "--jobs" not in " ".join(args) and "-j" not in args:
+            args = ["--jobs", "2"] + args
+            log("Running tests in parallel (2 workers)")
+        elif single_test_mode:
+            log("Running single test (no parallelization)")
+        else:
+            log("Running integration tests...")
+
         result = subprocess.run(
-            ["behave", str(test_dir)] + sys.argv[1:], cwd=Path(__file__).parent, env=env
+            ["behave", str(test_dir)] + args, cwd=Path(__file__).parent, env=env
         )
         return result.returncode
 

--- a/tests/mock-api-server/README.md
+++ b/tests/mock-api-server/README.md
@@ -47,8 +47,7 @@ The mock API is returning JSON that doesn't match the Rust structs generated fro
 
 4. **Run a single test with debug output**:
    ```bash
-   cd tests/integration
-   TOWER_API_URL=http://127.0.0.1:8000 uv run behave features/mcp_app_management.feature -n "Run simple application successfully locally" --no-capture
+   TOWER_API_URL=http://127.0.0.1:8000 ./tests/integration/run_tests.py -n "Run simple application successfully locally"
    ```
 
 ### Updating the Mock API
@@ -75,8 +74,8 @@ If the `User` model gains a new required field `department: String`, update the 
 
 After updating the mock API:
 
-1. Restart the mock server: `cd tests/mock-api-server && ./run.sh`
-2. Run the integration tests: `cd tests/integration && TOWER_MOCK_API_URL=http://127.0.0.1:8000 uv run behave features/`
+1. Restart the mock server: `tests/mock-api-server/run.sh`
+2. In another shell, run the integration tests: `./tests/integration/run_tests.py`
 3. Ensure all tests pass
 
 ## Files to Update

--- a/uv.lock
+++ b/uv.lock
@@ -2288,6 +2288,14 @@ dev = [
     { name = "pytest-httpx" },
     { name = "tower", extra = ["iceberg"] },
 ]
+test = [
+    { name = "aiohttp" },
+    { name = "behave" },
+    { name = "mcp", marker = "python_full_version >= '3.10'" },
+    { name = "pytest" },
+    { name = "pytest-env" },
+    { name = "pytest-httpx" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2322,6 +2330,14 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.3" },
     { name = "pytest-httpx", specifier = "==0.35.0" },
     { name = "tower", extras = ["iceberg"], editable = "." },
+]
+test = [
+    { name = "aiohttp", specifier = "==3.10.11" },
+    { name = "behave", specifier = "==1.3.3" },
+    { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.1.0" },
+    { name = "pytest", specifier = "==8.3.5" },
+    { name = "pytest-env", specifier = ">=1.1.3" },
+    { name = "pytest-httpx", specifier = "==0.35.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Similar to #105 this is pulled out of #103. In particular, this is all the error related changes — the hairiest part of the code for me and what made this whole thing take so freaking long. This was responsible for a lot of the tests failing (some of which are not yet committed into this branch because I'll add them in another PR).

Done:
- Convert deploy functions to return Results instead of void
- Add proper error variants for DeployApp and DescribeApp API errors
- Update MCP deploy tool to handle and report deploy failures
- Ensure deploy errors are properly propagated up the call stack
- Auto create apps in MCP server, otherwise it hangs on deploying
- Fix the validation error integration tests