### PR TITLE
Pass the current run ID as the parent_run_id when calling `run_app`

### DIFF
--- a/src/tower/_client.py
+++ b/src/tower/_client.py
@@ -74,6 +74,7 @@ def run_app(
     ctx = TowerContext.build()
     client = _env_client(ctx)
     run_params = RunAppParamsParameters()
+    parent_run_id = ctx.run_id
 
     if not environment:
         environment = ctx.environment
@@ -84,6 +85,7 @@ def run_app(
     input_body = RunAppParams(
         environment=environment,
         parameters=run_params,
+        parent_run_id=parent_run_id,
     )
 
     try:

--- a/src/tower/_context.py
+++ b/src/tower/_context.py
@@ -7,6 +7,7 @@ class TowerContext:
         tower_url: str,
         environment: str,
         api_key: str = None,
+        run_id: str = None,
         inference_router: str = None,
         inference_router_api_key: str = None,
         inference_provider: str = None,
@@ -15,6 +16,7 @@ class TowerContext:
         self.tower_url = tower_url
         self.environment = environment
         self.api_key = api_key
+        self.run_id = run_id
         self.jwt = jwt
         self.inference_router = inference_router
         self.inference_router_api_key = inference_router_api_key
@@ -34,6 +36,7 @@ class TowerContext:
         tower_environment = os.getenv("TOWER_ENVIRONMENT", "default")
         tower_api_key = os.getenv("TOWER_API_KEY")
         tower_jwt = os.getenv("TOWER_JWT")
+        tower_run_id = os.getenv("TOWER__RUNTIME__RUN_ID")
 
         # Replaces the deprecated hugging_face_provider and hugging_face_api_key
         inference_router = os.getenv("TOWER_INFERENCE_ROUTER")
@@ -44,6 +47,7 @@ class TowerContext:
             tower_url=tower_url,
             environment=tower_environment,
             api_key=tower_api_key,
+            run_id=tower_run_id,
             inference_router=inference_router,
             inference_router_api_key=inference_router_api_key,
             inference_provider=inference_provider,


### PR DESCRIPTION
This PR gets the current run ID from the context and passes it to the API when calling `run_app`. 