### PR TITLE
Always read jwt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
 name = "config"
 version = "0.3.37"
 dependencies = [
+ "base64",
  "chrono",
  "clap",
  "dirs",

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -7,9 +7,10 @@ rust-version = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-dirs = { workspace = true } 
+dirs = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -181,17 +181,15 @@ impl Config {
 
         configuration.base_path = base_path.to_string();
 
-        if let Some(session) = &self.session {
+        // Always read from disk to pick up team switches
+        if let Ok(session) = Session::from_config_dir() {
             if let Some(active_team) = &session.active_team {
-                // Use the active team's JWT token
                 configuration.bearer_access_token = Some(active_team.token.jwt.clone());
             } else {
-                // Fall back to session token if no active team
                 configuration.bearer_access_token = Some(session.token.jwt.clone());
             }
         }
 
-        // Store the configuration in self
         configuration
     }
 }


### PR DESCRIPTION
Changing team on the MCP server is broken, because we set the session JWT once on program startup. API calls now always read the session from disk. When using TOWER_JWT, the session is saved to disk with the correct active team based on the JWT's account ID.