### PR TITLE
chore: print all env vars in one go

### DIFF
--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -441,19 +441,19 @@ fn make_env_vars(
     debug!(ctx: &ctx, "converting {} env variables", (params.len() + secs.len()));
 
     for (key, value) in secs.into_iter() {
-        debug!(ctx: &ctx, "adding key {}", make_env_var_key(&key));
         res.insert(make_env_var_key(&key), value.to_string());
     }
 
     for (key, value) in params.into_iter() {
-        debug!(ctx: &ctx, "adding key {}", make_env_var_key(&key));
         res.insert(key.to_string(), value.to_string());
     }
 
     for (key, value) in other_env_vars.into_iter() {
-        debug!(ctx: &ctx, "adding key {}", &key);
         res.insert(key.to_string(), value.to_string());
     }
+
+    let added_keys = res.keys().map(|s| &**s).collect::<Vec<&str>>().join(", ");
+    debug!(ctx: &ctx, "added keys {}", &added_keys);
 
     // We also need a PYTHONPATH that is set to the current working directory to help with the
     // dependency resolution problem at runtime.


### PR DESCRIPTION
When trying to debug the broken merge parameters thing in the schedule, I noticed we have a lot of log spam for printing the env vars — a new line per environment variable. Given how many secrets we have in tower, this ends up being a lot...

<img width="1550" height="843" alt="Screenshot 2026-01-05 at 13 51 06" src="https://github.com/user-attachments/assets/4ad881c4-09b2-46c7-9ae2-8a275f258cf5" />
(but much more than that)

Since we add each env var to `res` anyway, I think it's neater to just print out the keys of `res`.

Before:
```
2026-01-05T15:16:12.409817Z DEBUG  adding key TOWER_INFERENCE_ROUTER

  2026-01-05T15:16:12.409826Z DEBUG  adding key AWS_REGION

  2026-01-05T15:16:12.409830Z DEBUG  adding key DUCKDB_DATASET_NAME

  2026-01-05T15:16:12.409832Z DEBUG  adding key SENTRY_DSN

  2026-01-05T15:16:12.409837Z DEBUG  adding key SLACK_WEBHOOK_URL

  2026-01-05T15:16:12.409841Z DEBUG  adding key PYICEBERG_CATALOG__DEFAULT__CREDENTIAL

  2026-01-05T15:16:12.409844Z DEBUG  adding key GITHUB_TOKEN

  2026-01-05T15:16:12.409846Z DEBUG  adding key my_secret

  2026-01-05T15:16:12.409851Z DEBUG  adding key DBT_SEED_ARCHIVE_URI

  2026-01-05T15:16:12.409855Z DEBUG  adding key DISCORD_BOT_TOKEN

  2026-01-05T15:16:12.409858Z DEBUG  adding key POSTGRES_URI

  2026-01-05T15:16:12.409861Z DEBUG  adding key DB_ANALYST_SLACK_BOT_TOKEN

  2026-01-05T15:16:12.409870Z DEBUG  adding key some-secret

  2026-01-05T15:16:12.409872Z DEBUG  adding key DBT_PROFILE_YAML

  2026-01-05T15:16:12.409876Z DEBUG  adding key TOWER_INFERENCE_ROUTER_API_KEY

  2026-01-05T15:16:12.409882Z DEBUG  adding key DUCKDB_FILE

  2026-01-05T15:16:12.409885Z DEBUG  adding key DUCKDB_PIPELINE_NAME

  2026-01-05T15:16:12.409889Z DEBUG  adding key foe

  2026-01-05T15:16:12.409892Z DEBUG  adding key friend

  2026-01-05T15:16:12.409895Z DEBUG  adding key PYICEBERG_CATALOG__DEFAULT__SCOPE

  2026-01-05T15:16:12.409899Z DEBUG  adding key TOWER_JWT

  2026-01-05T15:16:12.409902Z DEBUG  adding key PYICEBERG_CATALOG__DEFAULT__WAREHOUSE

  2026-01-05T15:16:12.409905Z DEBUG  adding key TOWER_URL

  2026-01-05T15:16:12.409907Z DEBUG  adding key PYICEBERG_CATALOG__DEFAULT__URI

  2026-01-05T15:16:12.409910Z DEBUG  adding key PYICEBERG_CATALOG__DEFAULT__CREDENTIAL
```
after
```
  2026-01-05T15:16:12.409921Z DEBUG  added keys POSTGRES_URI, PYICEBERG_CATALOG__DEFAULT__SCOPE, DBT_SEED_ARCHIVE_URI, GITHUB_TOKEN, foe, TOWER_URL, AWS_REGION, PYICEBERG_CATALOG__DEFAULT__CREDENTIAL, SENTRY_DSN, SLACK_WEBHOOK_URL, DUCKDB_DATASET_NAME, some-secret, TOWER_INFERENCE_ROUTER_API_KEY, friend, DISCORD_BOT_TOKEN, DUCKDB_PIPELINE_NAME, TOWER_JWT, my_secret, TOWER_INFERENCE_ROUTER, DBT_PROFILE_YAML, PYICEBERG_CATALOG__DEFAULT__WAREHOUSE, PYICEBERG_CATALOG__DEFAULT__URI, DUCKDB_FILE, DB_ANALYST_SLACK_BOT_TOKEN