### PR TITLE
Trying to fix release

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -36,3 +36,9 @@ runner = "ubuntu-latest"
 
 [dist.github-custom-runners.aarch64-unknown-linux-gnu]
 runner = "ubuntu-latest"
+
+[dist.github-custom-runners.x86_64-apple-darwin]
+runner = "macos-15"
+
+[dist.github-custom-runners.aarch64-apple-darwin]
+runner = "macos-15"


### PR DESCRIPTION
with 
```
dist plan --output-format=json | jq '.ci.github.artifacts_matrix'
```

## Before

```
{
  "include": [
    {
      "runner": "macos-13",
      "host": "x86_64-apple-darwin",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
      "targets": [
        "aarch64-apple-darwin"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-latest",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
      "targets": [
        "aarch64-unknown-linux-gnu"
      ],
      "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",                                                                                                                                                           
      "cache_provider": "github"
    },
    {
      "runner": "macos-13",
      "host": "x86_64-apple-darwin",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
      "targets": [
        "x86_64-apple-darwin"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-latest",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
      "targets": [
        "x86_64-unknown-linux-gnu"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-22.04",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
      "targets": [
        "x86_64-unknown-linux-musl"
      ],
      "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
      "cache_provider": "github"
    }
  ]
}
```

## After

```
{
  "include": [
    {
      "runner": "macos-15",
      "host": "aarch64-apple-darwin",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=aarch64-apple-darwin",
      "targets": [
        "aarch64-apple-darwin"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-latest",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=aarch64-unknown-linux-gnu",
      "targets": [
        "aarch64-unknown-linux-gnu"
      ],
      "packages_install": "if ! command -v cargo-zigbuild > /dev/null 2>&1; then\n  if ! command -v pip3 > /dev/null 2>&1; then\n    dnf install --assumeyes python3-pip\n    pip3 install --upgrade pip\n  fi\n  pip3 install cargo-zigbuild\nfi",                                                                                                                                                           
      "cache_provider": "github"
    },
    {
      "runner": "macos-15",
      "host": "aarch64-apple-darwin",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-apple-darwin",
      "targets": [
        "x86_64-apple-darwin"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-latest",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-unknown-linux-gnu",
      "targets": [
        "x86_64-unknown-linux-gnu"
      ],
      "cache_provider": "github"
    },
    {
      "runner": "ubuntu-22.04",
      "host": "x86_64-unknown-linux-gnu",
      "install_dist": {
        "shell": "sh",
        "run": "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/cargo-dist/releases/download/v0.28.5/cargo-dist-installer.sh | sh"
      },
      "dist_args": "--artifacts=local --target=x86_64-unknown-linux-musl",
      "targets": [
        "x86_64-unknown-linux-musl"
      ],
      "packages_install": "sudo apt-get update\nsudo apt-get install musl-tools",
      "cache_provider": "github"
    }
  ]
}
```