### PR TITLE
v0.3.39 re-re-release

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -36,3 +36,9 @@ runner = "ubuntu-latest"
 
 [dist.github-custom-runners.aarch64-unknown-linux-gnu]
 runner = "ubuntu-latest"
+
+[dist.github-custom-runners.x86_64-apple-darwin]
+runner = "macos-15"
+
+[dist.github-custom-runners.aarch64-apple-darwin]
+runner = "macos-15"


### PR DESCRIPTION
⚠️ An issue with our production release script (addressed below) means we have to rerelease v0.3.39. In addition to previously-landed changes we have the following.

- Updates to how env vars are printed
- Expose exit code crashes to local app runs
- Upgrade to newer macos images used during release as the old ones were deprecated.