### PR TITLE
fix: upgrade http to https in session URL for non-local hosts

### DIFF
--- a/crates/tower-cmd/src/session.rs
+++ b/crates/tower-cmd/src/session.rs
@@ -115,8 +115,12 @@ fn finalize_session(
 ) {
     let mut session = Session::from_api_session(&session_response.session);
 
-    // we have to copy in the tower URL so that we save it for later on!
-    session.tower_url = config.tower_url.clone();
+    let mut url = config.tower_url.clone();
+    let local = matches!(url.host_str(), Some("localhost" | "127.0.0.1" | "::1"));
+    if url.scheme() == "http" && !local {
+        let _ = url.set_scheme("https");
+    }
+    session.tower_url = url;
 
     if let Err(err) = session.save() {
         spinner.failure();


### PR DESCRIPTION
When logging in with an http:// tower URL against a remote server, subsequent POST requests (like session refresh) get silently downgraded to GET on 301/302 redirects per RFC 7231, causing 404s. This upgrades http to https at login time for non-localhost URLs.