### PR TITLE
Use API key from environment if available

### DIFF
--- a/tests/integration/features/environment.py
+++ b/tests/integration/features/environment.py
@@ -19,6 +19,7 @@ def before_scenario(context, scenario):
     # Create a temporary working directory for this scenario
     context.temp_dir = tempfile.mkdtemp(prefix="tower_test_")
     context.original_cwd = os.getcwd()
+    context.api_key = os.environ.get("TOWER_API_KEY", "sk-test-api-key")
     os.chdir(context.temp_dir)
 
 

--- a/tests/integration/features/steps/cli_steps.py
+++ b/tests/integration/features/steps/cli_steps.py
@@ -70,7 +70,7 @@ def step_run_cli_command_with_api_key(context, command):
         test_env["FORCE_COLOR"] = "1"
         test_env["CLICOLOR_FORCE"] = "1"
         test_env["TOWER_URL"] = context.tower_url
-        test_env["TOWER_API_KEY"] = "sk-test-api-key"
+        test_env["TOWER_API_KEY"] = context.api_key
 
         # Use a temp HOME with no session.json to prove API key auth works standalone
         test_env["HOME"] = context.temp_dir


### PR DESCRIPTION
This PR passes the API key via context, and gets it from the environment if available, rather than hardcoding a test API key. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated integration test infrastructure for improved API key configuration handling in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->