### PR TITLE
feat(TOW-1415): Claude Code plugin with bundled MCP server and skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "tower",
+  "description": "Tower compute platform — run and deploy Python apps, pipelines, and AI agents",
+  "version": "1.0.0",
+  "author": {
+    "name": "Tower",
+    "url": "https://tower.dev"
+  },
+  "homepage": "https://tower.dev/docs",
+  "repository": "https://github.com/tower/tower-cli",
+  "license": "MIT"
+}

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+language: en-US
+reviews:
+  base_branches:
+    - develop

--- a/.github/workflows/regenerate-skill.yml
+++ b/.github/workflows/regenerate-skill.yml
@@ -1,0 +1,47 @@
+name: Regenerate SKILL.md
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'crates/tower-cmd/**'
+      - 'crates/tower/**'
+      - 'skills/tower/SKILL.md'
+      - '.github/workflows/regenerate-skill.yml'
+
+concurrency:
+  group: regenerate-skill
+  cancel-in-progress: false
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Regenerate SKILL.md
+        run: cargo run --quiet --bin tower -- skill generate > skills/tower/SKILL.md
+
+      - name: Open PR if SKILL.md changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: regenerate SKILL.md"
+          title: "chore: regenerate SKILL.md"
+          body: |
+            `tower skill generate` output has drifted from the checked-in `skills/tower/SKILL.md`.
+
+            This PR was opened automatically by the `Regenerate SKILL.md` workflow after a merge to `develop`.
+          branch: chore/regenerate-skill
+          base: develop
+          delete-branch: true
+          add-paths: skills/tower/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pytest.ini
 
 # wheel build artifacts
 *.data/
+
+# local MCP overrides (e.g. internal tooling with secrets)
+.mcp.json.local

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "tower": {
+      "command": "uvx",
+      "args": ["tower", "mcp-server"]
+    }
+  }
+}

--- a/crates/tower-cmd/src/apps.rs
+++ b/crates/tower-cmd/src/apps.rs
@@ -11,7 +11,7 @@ pub fn apps_cmd() -> Command {
     Command::new("apps")
         .about("Manage the apps in your current Tower account")
         .arg_required_else_help(true)
-        .subcommand(Command::new("list").about("List all of your apps"))
+        .subcommand(Command::new("list").about("List all apps in your Tower account"))
         .subcommand(
             Command::new("show")
                 .arg(
@@ -21,7 +21,7 @@ pub fn apps_cmd() -> Command {
                         .required(true)
                         .help("Name of the app"),
                 )
-                .about("Show the details about an app in Tower"),
+                .about("Show details for a Tower app and its recent runs"),
         )
         .subcommand(
             Command::new("logs")

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -14,6 +14,7 @@ mod run;
 mod schedules;
 mod secrets;
 mod session;
+mod skill;
 mod teams;
 mod towerfile_gen;
 mod util;
@@ -201,6 +202,13 @@ impl App {
                     }
                 }
             }
+            Some(("skill", sub_matches)) => match sub_matches.subcommand() {
+                Some(("generate", _)) => skill::do_skill_generate(root_cmd()).await,
+                _ => {
+                    skill::skill_cmd().print_help().unwrap();
+                    std::process::exit(2);
+                }
+            },
             Some(("mcp-server", args)) => mcp::do_mcp_server(sessionized_config, args)
                 .await
                 .unwrap_or_else(|e| {
@@ -255,4 +263,5 @@ fn root_cmd() -> Command {
         .subcommand(version::version_cmd())
         .subcommand(teams::teams_cmd())
         .subcommand(mcp::mcp_cmd())
+        .subcommand(skill::skill_cmd())
 }

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -460,7 +460,11 @@ impl TowerService {
         (result, output)
     }
 
-    #[tool(description = "List all Tower apps in your account")]
+    // Tool descriptions below should stay in sync with .about() in the corresponding command
+    // files (apps.rs, secrets.rs, etc.). Proc macros require string literals so they can't
+    // share constants directly. MCP-only descriptions (with Prerequisites/Optional) are
+    // intentionally more detailed and don't need a CLI counterpart.
+    #[tool(description = "List all apps in your Tower account")]
     async fn tower_apps_list(&self) -> Result<CallToolResult, McpError> {
         match api::list_apps(&self.config).await {
             Ok(response) => {

--- a/crates/tower-cmd/src/secrets.rs
+++ b/crates/tower-cmd/src/secrets.rs
@@ -38,7 +38,7 @@ pub fn secrets_cmd() -> Command {
                         .help("List secrets across all environments")
                         .action(clap::ArgAction::SetTrue),
                 )
-                .about("List all of your secrets"),
+                .about("List secrets in your Tower account"),
         )
         .subcommand(
             Command::new("create")

--- a/crates/tower-cmd/src/skill.rs
+++ b/crates/tower-cmd/src/skill.rs
@@ -109,7 +109,11 @@ fn append_command(out: &mut String, cmd: &Command, path: &[&str], depth: usize) 
     }
 }
 
-const WORKFLOW_HEADER: &str = r#"# Tower Skill
+const WORKFLOW_HEADER: &str = r#"---
+description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
+---
+
+# Tower Skill
 
 Tower is a compute platform for Python data apps, pipelines, and AI agents.
 
@@ -117,25 +121,47 @@ Tower is a compute platform for Python data apps, pipelines, and AI agents.
 
 ## Setup
 
-Check whether Tower is configured:
+First, check if Tower is already installed and authenticated:
 
 ```bash
 tower teams list
 ```
 
-If that works, you're authenticated. If not, run:
+If that works, skip to the workflow. Otherwise, install and log in.
+
+### Install
+
+Preferred — `uvx` runs Tower with no global install (requires `uv`):
 
 ```bash
 uvx tower login
 ```
 
-`uvx` runs Tower with no global install. To start the MCP server so Claude Code can use it:
+If you don't have `uvx`, install with pip (Python ≥ 3.9):
 
 ```bash
-uvx tower mcp-server
+pip install tower
+tower login
 ```
 
-Add that to your Claude Code MCP config so it starts automatically.
+Or with nix:
+
+```bash
+nix run nixpkgs#tower -- login
+```
+
+### MCP server
+
+The MCP server gives Claude structured access to Tower tools. If it's not already running (you'll see `tower_*` tools available), start it:
+
+```bash
+uvx tower mcp-server          # if using uvx
+tower mcp-server              # if installed via pip/nix
+```
+
+If you installed Tower via the Claude Code plugin, this is already configured. Otherwise, copy the `.mcp.json` from the [tower-cli repo](https://github.com/tower/tower-cli) into your project root.
+
+**If MCP tools are unavailable**, fall back to the CLI equivalents — every MCP tool has a direct CLI counterpart (e.g. `tower apps list`, `tower deploy`).
 
 ## MCP-First, CLI as Fallback
 

--- a/crates/tower-cmd/src/skill.rs
+++ b/crates/tower-cmd/src/skill.rs
@@ -1,0 +1,217 @@
+use clap::Command;
+
+pub fn skill_cmd() -> Command {
+    Command::new("skill")
+        .about("Generate Claude Code skill files for AI agent integration")
+        .arg_required_else_help(true)
+        .subcommand(
+            Command::new("generate")
+                .about("Generate a SKILL.md describing how to use Tower with AI agents"),
+        )
+}
+
+pub async fn do_skill_generate(root: Command) {
+    let content = generate_skill_md(root);
+    print!("{}", content);
+}
+
+fn generate_skill_md(root: Command) -> String {
+    let mut out = String::new();
+
+    out.push_str(WORKFLOW_HEADER);
+    out.push_str("\n\n");
+    out.push_str("## Command Reference\n\n");
+    out.push_str("*This section is generated from the CLI's built-in help.*\n\n");
+
+    append_command(&mut out, &root, &[], 3);
+
+    out
+}
+
+fn append_command(out: &mut String, cmd: &Command, path: &[&str], depth: usize) {
+    let subcommands: Vec<_> = cmd
+        .get_subcommands()
+        .filter(|c| !c.is_hide_set())
+        .collect();
+
+    for sub in &subcommands {
+        let name = sub.get_name();
+        let mut full_path = path.to_vec();
+        full_path.push(name);
+
+        let heading = "#".repeat(depth);
+        let cmd_str = format!("tower {}", full_path.join(" "));
+        out.push_str(&format!("{} `{}`\n\n", heading, cmd_str));
+
+        if let Some(about) = sub.get_about() {
+            out.push_str(&format!("{}\n\n", about));
+        }
+
+        // Positional args
+        let positional: Vec<_> = sub
+            .get_arguments()
+            .filter(|a| a.is_positional() && !a.is_hide_set())
+            .collect();
+
+        // Named args / flags
+        let named: Vec<_> = sub
+            .get_arguments()
+            .filter(|a| !a.is_positional() && !a.is_hide_set() && a.get_long().is_some())
+            .collect();
+
+        if !positional.is_empty() || !named.is_empty() {
+            out.push_str("**Arguments:**\n\n");
+            for arg in &positional {
+                let req = if arg.is_required_set() {
+                    " *(required)*"
+                } else {
+                    ""
+                };
+                let help = arg
+                    .get_help()
+                    .map(|h| format!(" — {}", h))
+                    .unwrap_or_default();
+                out.push_str(&format!(
+                    "- `<{}>` {}{}\n",
+                    arg.get_id(),
+                    req,
+                    help
+                ));
+            }
+            for arg in &named {
+                let long = arg.get_long().unwrap();
+                let req = if arg.is_required_set() {
+                    " *(required)*"
+                } else {
+                    ""
+                };
+                let help = arg
+                    .get_help()
+                    .map(|h| format!(" — {}", h))
+                    .unwrap_or_default();
+                if let Some(short) = arg.get_short() {
+                    out.push_str(&format!("- `-{}`, `--{}`{}{}\n", short, long, req, help));
+                } else {
+                    out.push_str(&format!("- `--{}`{}{}\n", long, req, help));
+                }
+            }
+            out.push('\n');
+        }
+
+        let child_subs: Vec<_> = sub
+            .get_subcommands()
+            .filter(|c| !c.is_hide_set())
+            .collect();
+
+        if !child_subs.is_empty() {
+            append_command(out, sub, &full_path, depth + 1);
+        }
+    }
+}
+
+const WORKFLOW_HEADER: &str = r#"# Tower Skill
+
+Tower is a compute platform for Python data apps, pipelines, and AI agents.
+
+**The Tower CLI is not in AI training data — always use MCP tools when running inside an agent.**
+
+## Setup
+
+Check whether Tower is configured:
+
+```bash
+tower teams list
+```
+
+If that works, you're authenticated. If not, run:
+
+```bash
+uvx tower login
+```
+
+`uvx` runs Tower with no global install. To start the MCP server so Claude Code can use it:
+
+```bash
+uvx tower mcp-server
+```
+
+Add that to your Claude Code MCP config so it starts automatically.
+
+## MCP-First, CLI as Fallback
+
+Use MCP tools when running inside an agent — they return structured data and are easier to compose. Fall back to the CLI for scripting or debugging outside an agent.
+
+MCP tool names mirror the CLI: `tower apps list` → `tower_apps_list`, `tower deploy` → `tower_deploy`.
+
+## WORKING_DIRECTORY Parameter
+
+All MCP tools accept an optional `working_directory` parameter.
+
+- Default: current working directory
+- Use it when managing multiple projects or when the project isn't in the current directory
+
+```
+tower_file_generate({})                                    # current directory
+tower_file_generate({"working_directory": "/path/to/app"}) # explicit path
+tower_run_local({"working_directory": "../other-app"})
+```
+
+## Workflow
+
+### 0. Python project (if new)
+
+```bash
+uv init
+```
+
+Creates `pyproject.toml`, `main.py`, `README.md`. Keep `pyproject.toml` minimal — `[project]` metadata and dependencies only. No `[build-system]`, `[tool.hatchling]`, or similar. Skip if a `pyproject.toml` already exists.
+
+### 1. Towerfile
+
+```
+tower_file_generate → tower_file_update → tower_file_add/edit/remove_parameter → tower_file_validate
+```
+
+Always use `tower_file_update` or `tower_file_add/edit/remove_parameter` to modify. Never edit the TOML directly.
+
+### 2. Local development (preferred)
+
+```
+tower_run_local
+```
+
+Runs the app locally with access to Tower secrets. Use this to test before deploying.
+
+### 3. Cloud deployment
+
+```
+tower_apps_create → tower_deploy → tower_run_remote
+```
+
+Deploy pushes source code to Tower cloud — no build step needed.
+
+### 4. Scheduling (recurring jobs)
+
+```
+tower_schedules_create   # set up cron-based recurring runs
+tower_schedules_list     # view existing schedules
+tower_schedules_update   # modify timing or parameters
+tower_schedules_delete   # remove a schedule
+```
+
+### 5. Management & monitoring
+
+```
+tower_apps_list                              # list all apps
+tower_apps_show                              # details and recent runs
+tower_apps_logs                              # logs from a specific run
+tower_teams_list, tower_teams_switch         # manage team context
+tower_secrets_create, tower_secrets_list     # store credentials and API keys
+```
+
+## Reminders
+
+- Tower deploys source code directly — no build tools needed
+- Use Tower secrets for sensitive data (database credentials, API keys)
+- Prefer `tower_run_local` during development — faster, and has secret access
+- Always use MCP tools to modify Towerfiles (never edit TOML files manually)"#;

--- a/skills/tower/SKILL.md
+++ b/skills/tower/SKILL.md
@@ -149,11 +149,11 @@ Manage the apps in your current Tower account
 
 #### `tower apps list`
 
-List all of your apps
+List all apps in your Tower account
 
 #### `tower apps show`
 
-Show the details about an app in Tower
+Show details for a Tower app and its recent runs
 
 **Arguments:**
 
@@ -194,6 +194,28 @@ Cancel a running app run
 
 - `<app_name>`  *(required)* — Name of the app
 - `<run_number>`  *(required)* — Run number to cancel
+
+### `tower catalogs`
+
+Interact with the catalogs in your Tower account
+
+#### `tower catalogs list`
+
+List all of your catalogs
+
+**Arguments:**
+
+- `-e`, `--environment` — List catalogs in this environment
+- `-a`, `--all` — List catalogs across all environments
+
+#### `tower catalogs show`
+
+Show the details of a catalog, including its property names
+
+**Arguments:**
+
+- `<catalog_name>`  *(required)* — Name of the catalog
+- `-e`, `--environment` — Environment the catalog belongs to
 
 ### `tower schedules`
 
@@ -243,7 +265,7 @@ Interact with the secrets in your Tower account
 
 #### `tower secrets list`
 
-List all of your secrets
+List secrets in your Tower account
 
 **Arguments:**
 
@@ -344,3 +366,4 @@ Generate Claude Code skill files for AI agent integration
 #### `tower skill generate`
 
 Generate a SKILL.md describing how to use Tower with AI agents
+

--- a/skills/tower/SKILL.md
+++ b/skills/tower/SKILL.md
@@ -1,0 +1,324 @@
+---
+description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
+---
+
+# Tower Skill
+
+Tower is a compute platform for Python data apps, pipelines, and AI agents.
+
+**The Tower CLI is not in AI training data — always use MCP tools when running inside an agent.**
+
+## Setup
+
+Check whether Tower is configured:
+
+```bash
+tower teams list
+```
+
+If that works, you're authenticated. If not, run:
+
+```bash
+uvx tower login
+```
+
+`uvx` runs Tower with no global install. To start the MCP server so Claude Code can use it:
+
+```bash
+uvx tower mcp-server
+```
+
+Add that to your Claude Code MCP config so it starts automatically.
+
+## MCP-First, CLI as Fallback
+
+Use MCP tools when running inside an agent — they return structured data and are easier to compose. Fall back to the CLI for scripting or debugging outside an agent.
+
+MCP tool names mirror the CLI: `tower apps list` → `tower_apps_list`, `tower deploy` → `tower_deploy`.
+
+## WORKING_DIRECTORY Parameter
+
+All MCP tools accept an optional `working_directory` parameter.
+
+- Default: current working directory
+- Use it when managing multiple projects or when the project isn't in the current directory
+
+```
+tower_file_generate({})                                    # current directory
+tower_file_generate({"working_directory": "/path/to/app"}) # explicit path
+tower_run_local({"working_directory": "../other-app"})
+```
+
+## Workflow
+
+### 0. Python project (if new)
+
+```bash
+uv init
+```
+
+Creates `pyproject.toml`, `main.py`, `README.md`. Keep `pyproject.toml` minimal — `[project]` metadata and dependencies only. No `[build-system]`, `[tool.hatchling]`, or similar. Skip if a `pyproject.toml` already exists.
+
+### 1. Towerfile
+
+```
+tower_file_generate → tower_file_update → tower_file_add/edit/remove_parameter → tower_file_validate
+```
+
+Always use `tower_file_update` or `tower_file_add/edit/remove_parameter` to modify. Never edit the TOML directly.
+
+### 2. Local development (preferred)
+
+```
+tower_run_local
+```
+
+Runs the app locally with access to Tower secrets. Use this to test before deploying.
+
+### 3. Cloud deployment
+
+```
+tower_apps_create → tower_deploy → tower_run_remote
+```
+
+Deploy pushes source code to Tower cloud — no build step needed.
+
+### 4. Scheduling (recurring jobs)
+
+```
+tower_schedules_create   # set up cron-based recurring runs
+tower_schedules_list     # view existing schedules
+tower_schedules_update   # modify timing or parameters
+tower_schedules_delete   # remove a schedule
+```
+
+### 5. Management & monitoring
+
+```
+tower_apps_list                              # list all apps
+tower_apps_show                              # details and recent runs
+tower_apps_logs                              # logs from a specific run
+tower_teams_list, tower_teams_switch         # manage team context
+tower_secrets_create, tower_secrets_list     # store credentials and API keys
+```
+
+## Reminders
+
+- Tower deploys source code directly — no build tools needed
+- Use Tower secrets for sensitive data (database credentials, API keys)
+- Prefer `tower_run_local` during development — faster, and has secret access
+- Always use MCP tools to modify Towerfiles (never edit TOML files manually)
+
+## Command Reference
+
+*This section is generated from the CLI's built-in help.*
+
+### `tower login`
+
+Create a session with Tower
+
+**Arguments:**
+
+- `-n`, `--no-browser` — Do not attempt to open the browser automatically
+
+### `tower apps`
+
+Manage the apps in your current Tower account
+
+#### `tower apps list`
+
+List all of your apps
+
+#### `tower apps show`
+
+Show the details about an app in Tower
+
+**Arguments:**
+
+- `<app_name>`  *(required)* — Name of the app
+
+#### `tower apps logs`
+
+Get the logs from a previous Tower app run
+
+**Arguments:**
+
+- `<app_name>`  *(required)* — app_name#run_number
+- `<run_number>` 
+- `-f`, `--follow` — Follow logs in real time
+
+#### `tower apps create`
+
+Create a new app in Tower
+
+**Arguments:**
+
+- `-n`, `--name` *(required)*
+- `--description`
+
+#### `tower apps delete`
+
+Delete an app in Tower
+
+**Arguments:**
+
+- `<app_name>`  *(required)* — Name of the app
+
+#### `tower apps cancel`
+
+Cancel a running app run
+
+**Arguments:**
+
+- `<app_name>`  *(required)* — Name of the app
+- `<run_number>`  *(required)* — Run number to cancel
+
+### `tower schedules`
+
+Manage schedules for your Tower apps
+
+#### `tower schedules list`
+
+List all schedules
+
+**Arguments:**
+
+- `-a`, `--app` — Filter schedules by app name
+- `-e`, `--environment` — Filter schedules by environment
+
+#### `tower schedules create`
+
+Create a new schedule for an app
+
+**Arguments:**
+
+- `-a`, `--app` *(required)* — The name of the app to schedule
+- `-e`, `--environment` — The environment to run the app in
+- `-c`, `--cron` *(required)* — The cron expression defining when the app should run
+- `-p`, `--parameter` — Parameters (key=value) to pass to the app
+
+#### `tower schedules delete`
+
+Delete a schedule
+
+**Arguments:**
+
+- `<schedule_id>`  *(required)* — The schedule ID to delete
+
+#### `tower schedules update`
+
+Update an existing schedule
+
+**Arguments:**
+
+- `<id_or_name>`  *(required)* — ID or name of the schedule to update
+- `-c`, `--cron` — The cron expression defining when the app should run
+- `-p`, `--parameter` — Parameters (key=value) to pass to the app
+
+### `tower secrets`
+
+Interact with the secrets in your Tower account
+
+#### `tower secrets list`
+
+List all of your secrets
+
+**Arguments:**
+
+- `-s`, `--show` — Show secrets in plain text
+- `-e`, `--environment` — List secrets in this environment
+- `-a`, `--all` — List secrets across all environments
+
+#### `tower secrets create`
+
+Create a new secret in your Tower account
+
+**Arguments:**
+
+- `-n`, `--name` *(required)* — Secret name to create
+- `-e`, `--environment` — Environment to store the secret in
+- `-v`, `--value` *(required)* — Secret value to store
+
+#### `tower secrets delete`
+
+Delete a secret in Tower
+
+**Arguments:**
+
+- `<secret_name>`  *(required)* — secret name, or environment/secret_name
+- `-e`, `--environment` — environment to delete the secret from
+
+### `tower environments`
+
+Manage the environments in your current Tower account
+
+#### `tower environments list`
+
+List all of your environments
+
+#### `tower environments create`
+
+Create a new environment in Tower
+
+**Arguments:**
+
+- `-n`, `--name` *(required)*
+
+### `tower deploy`
+
+Deploy your latest code to Tower
+
+**Arguments:**
+
+- `-d`, `--dir` — The directory containing the app to deploy
+- `-f`, `--create` — Automatically force creation of the app if it doesn't already exist
+
+### `tower run`
+
+Run your code in Tower or locally
+
+**Arguments:**
+
+- `<app_name>`  — Name of a deployed app to run (uses ./Towerfile if omitted)
+- `--dir` — The directory containing the Towerfile
+- `--local` — Run this app locally
+- `-e`, `--environment` — The environment to invoke the app in
+- `-p`, `--parameter` — Parameters (key=value) to pass to the app
+- `-d`, `--detached` — Don't follow the run output in your CLI
+
+### `tower version`
+
+Print the current version of Tower
+
+### `tower teams`
+
+View information about team membership and switch between teams
+
+#### `tower teams list`
+
+List teams you belong to
+
+#### `tower teams switch`
+
+Switch context to a different team
+
+**Arguments:**
+
+- `<team_name>`  *(required)* — Name of the team to switch to
+
+### `tower mcp-server`
+
+Runs an MCP server for LLM interaction
+
+**Arguments:**
+
+- `-t`, `--transport` — Transport mode
+- `-p`, `--port` — Port for HTTP/SSE server (default: 34567)
+
+### `tower skill`
+
+Generate Claude Code skill files for AI agent integration
+
+#### `tower skill generate`
+
+Generate a SKILL.md describing how to use Tower with AI agents

--- a/skills/tower/SKILL.md
+++ b/skills/tower/SKILL.md
@@ -10,25 +10,47 @@ Tower is a compute platform for Python data apps, pipelines, and AI agents.
 
 ## Setup
 
-Check whether Tower is configured:
+First, check if Tower is already installed and authenticated:
 
 ```bash
 tower teams list
 ```
 
-If that works, you're authenticated. If not, run:
+If that works, skip to the workflow. Otherwise, install and log in.
+
+### Install
+
+Preferred — `uvx` runs Tower with no global install (requires `uv`):
 
 ```bash
 uvx tower login
 ```
 
-`uvx` runs Tower with no global install. To start the MCP server so Claude Code can use it:
+If you don't have `uvx`, install with pip (Python ≥ 3.9):
 
 ```bash
-uvx tower mcp-server
+pip install tower
+tower login
 ```
 
-Add that to your Claude Code MCP config so it starts automatically.
+Or with nix:
+
+```bash
+nix run nixpkgs#tower -- login
+```
+
+### MCP server
+
+The MCP server gives Claude structured access to Tower tools. If it's not already running (you'll see `tower_*` tools available), start it:
+
+```bash
+uvx tower mcp-server          # if using uvx
+tower mcp-server              # if installed via pip/nix
+```
+
+If you installed Tower via the Claude Code plugin, this is already configured. Otherwise, copy the `.mcp.json` from the [tower-cli repo](https://github.com/tower/tower-cli) into your project root.
+
+**If MCP tools are unavailable**, fall back to the CLI equivalents — every MCP tool has a direct CLI counterpart (e.g. `tower apps list`, `tower deploy`).
 
 ## MCP-First, CLI as Fallback
 


### PR DESCRIPTION
## Summary

Ships tower-cli as a Claude Code plugin. Users can install the whole thing — MCP server + skill — directly from this GitHub repo.

- `.claude-plugin/plugin.json` — plugin manifest (name, version, metadata)
- `.mcp.json` — starts `uvx tower mcp-server` via stdio so Claude has structured Tower tools available
- `skills/tower/SKILL.md` — generated from `tower skill generate` with auth detection and install fallbacks (uvx → pip → nix)
- `tower skill generate` — new CLI subcommand that emits the skill doc from clap metadata so the command reference stays in sync with the CLI
- CLI `.about()` strings aligned with MCP tool descriptions where they'd drifted; sync comment added in `mcp.rs` (proc macros can't reference constants so full single-source would need a build script)

## Notes

The existing `.mcp.json` (with dev-only Grafana config) has moved to `.mcp.json.local` and is gitignored. Developers who want both can keep their local overrides there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `skill generate` subcommand for generating workflow documentation.
  * Added MCP (Model Context Protocol) server configuration support.

* **Documentation**
  * Added comprehensive Tower CLI setup and usage guide with command reference.

* **Chores**
  * Updated CLI help text for improved clarity across `apps`, `secrets`, and related commands.
  * Added plugin metadata and GitHub Actions workflow for documentation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->