### PR TITLE
fix: skip empty env vars for iceberg catalogs

### DIFF
--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -629,6 +629,7 @@ async fn get_catalogs(
                     })?;
             let name = property
                 .environment_variable
+                .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| {
                     create_pyiceberg_catalog_property_name(&catalog.name, &property.name)
                 });


### PR DESCRIPTION
As raised by coderabbit (but I think this solution is equivalent to its, and a bit simpler)