### PR TITLE
fix: drop ring from TLS path; bump aarch64 wheel base to manylinux_2_28

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -268,7 +268,7 @@ jobs:
         uses: PyO3/maturin-action@v1.50.1
         with:
           target: ${{ matrix.platform.target }}
-          manylinux: auto
+          manylinux: 2_28
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist -i python3.10 python3.11 python3.12 python3.13 python3.14
         env:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -273,11 +273,6 @@ jobs:
           args: --release --locked --out dist -i python3.10 python3.11 python3.12 python3.13 python3.14
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-          # Set the CFLAGS for the aarch64 target, defining the ARM architecture
-          # for the ring crate's build script. This is a workaround for the
-          # issue where the ring crate's build script is not able to detect the
-          # ARM architecture.
-          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a -D__ARM_ARCH=8"
       - uses: uraimo/run-on-arch-action@v2
         if: ${{ matrix.platform.arch != 'ppc64' && matrix.platform.arch != 'ppc64le'}}
         name: Test wheel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +364,8 @@ version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -461,6 +485,15 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -899,6 +932,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1061,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1148,10 +1193,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1161,11 +1204,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1657,6 +1698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,12 +1811,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maplit"
@@ -2298,61 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
-dependencies = [
- "bytes",
- "getrandom 0.3.3",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.5.10",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,7 +2546,6 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2699,12 +2688,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,8 +2719,8 @@ version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2750,7 +2733,6 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2760,6 +2742,7 @@ version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3456,21 +3439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tmpdir"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,6 +3648,7 @@ dependencies = [
  "rmcp",
  "rpassword",
  "rsa",
+ "rustls",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -3794,6 +3763,7 @@ dependencies = [
  "hex",
  "regex",
  "reqwest",
+ "rustls",
  "seahash",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,9 @@ pyo3 = { version = "0.28", features = ["extension-module"] }
 promptly = "0.3"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider", "stream"] }
 reqwest-eventsource = { version = "0.6" }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std", "tls12"] }
 rpassword = "7"
 rsa = "0.9"
 seahash = "4.1"

--- a/crates/tower-api/Cargo.toml
+++ b/crates/tower-api/Cargo.toml
@@ -12,4 +12,4 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls-webpki-roots-no-provider"] }

--- a/crates/tower-cmd/Cargo.toml
+++ b/crates/tower-cmd/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 rpassword = { workspace = true }
 rsa = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -30,6 +30,8 @@ pub struct App {
 
 impl App {
     pub fn new() -> Self {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let cmd = root_cmd();
 
         // When TOWER_API_KEY is set, skip session entirely — the API key is self-contained

--- a/crates/tower-uv/Cargo.toml
+++ b/crates/tower-uv/Cargo.toml
@@ -15,6 +15,7 @@ futures-lite = { workspace = true }
 hex = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
 seahash = { workspace = true }
 tokio = { workspace = true }
 tokio-tar = { workspace = true }

--- a/crates/tower-uv/src/install.rs
+++ b/crates/tower-uv/src/install.rs
@@ -211,6 +211,8 @@ async fn download_uv_archive(path: &PathBuf, archive: String) -> Result<PathBuf,
     // Create the directory if it doesn't exist
     std::fs::create_dir_all(&path).map_err(Error::IoError)?;
 
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // Download the file
     let response = reqwest::get(url)
         .await

--- a/scripts/rust-client-templates/Cargo.mustache
+++ b/scripts/rust-client-templates/Cargo.mustache
@@ -44,7 +44,7 @@ reqwest-middleware = { version = "^0.4", features = ["json", "blocking", "multip
 {{/supportMiddleware}}
 {{/supportAsync}}
 {{#supportAsync}}
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "rustls-tls-webpki-roots-no-provider"] }
 {{#supportMiddleware}}
 reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }
 {{/supportMiddleware}}


### PR DESCRIPTION
`tower login` fails inside `python:3.11-slim-bookworm` on aarch64. The handshake to api.tower.dev errors out. Same wheel works on Alpine and on x86_64.

Cause: rustls uses ring as its crypto provider (because `reqwest/rustls-tls` pulls it in), and ring's aarch64 asm gets miscompiled by manylinux2014's toolchain (CentOS 7, GCC 4.8) for glibc 2.36+.

Two changes, either one would fix it:

1. Bump the aarch64 wheel base from `manylinux2014` to `manylinux_2_28` (AlmaLinux 8, GCC 8+).
2. Replace ring with aws-lc-rs as the rustls provider — swap every `reqwest/rustls-tls*` feature for the `-no-provider` variant and install `aws_lc_rs::default_provider()` at startup.

Also patches `scripts/rust-client-templates/Cargo.mustache` so the next regen of `tower-api` keeps the aws-lc-rs feature, and removes the now-dead `CFLAGS_aarch64_unknown_linux_gnu` ring workaround from the workflow.

## Repro

Before, on an arm64 host:
```
$ docker run --rm -it --platform linux/arm64 python:3.11-slim-bookworm bash
# pip install tower==0.3.61
# tower login
... Failed to create device login ticket: error sending request for url (https://api.tower.dev/v1/login/device)
```

After, wheel built from this branch in the same container:
```
# tower login
... Please open the following URL in your browser:
https://app.tower.dev/login/device?user_code=...
```