### PR TITLE
Fix local PYTHONPATH join

### DIFF
--- a/crates/tower-package/src/towerfile.rs
+++ b/crates/tower-package/src/towerfile.rs
@@ -76,9 +76,28 @@ impl Towerfile {
             return Err(Error::MissingRequiredAppField {
                 field: "name".to_string(),
             });
-        } else {
-            Ok(towerfile)
         }
+
+        for import_path in &towerfile.app.import_paths {
+            let as_str = import_path.to_string_lossy();
+            if as_str.is_empty() {
+                return Err(Error::InvalidTowerfile {
+                    message: "import_paths entries must not be empty".to_string(),
+                });
+            }
+            // PATH-style separators in a single entry would break PYTHONPATH construction at
+            // runtime, since each entry is joined with the platform path separator.
+            if as_str.contains(|c: char| c == ':' || c == ';') {
+                return Err(Error::InvalidTowerfile {
+                    message: format!(
+                        "import_paths entry {:?} contains an illegal character (':' or ';')",
+                        as_str
+                    ),
+                });
+            }
+        }
+
+        Ok(towerfile)
     }
 
     /// set_parameter upserts a parameter by lookup name. If a parameter with the given name

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -161,31 +161,17 @@ async fn inner_execute_local_app(
     let manifest = &package.manifest;
     let secrets = opts.secrets;
     let params = opts.parameters;
-    let mut other_env_vars = opts.env_vars;
+    let other_env_vars = opts.env_vars;
 
-    if !package.manifest.import_paths.is_empty() {
-        debug!(ctx: &ctx, "adding import paths to PYTHONPATH: {:?}", package.manifest.import_paths);
+    let import_paths: Vec<PathBuf> = package
+        .manifest
+        .import_paths
+        .iter()
+        .map(|p| package_path.join(p))
+        .collect();
 
-        let import_paths = package
-            .manifest
-            .import_paths
-            .iter()
-            .map(|p| package_path.join(p))
-            .collect::<Vec<_>>();
-
-        let import_paths = std::env::join_paths(import_paths)?
-            .to_string_lossy()
-            .to_string();
-
-        if let Some(existing) = other_env_vars.get("PYTHONPATH") {
-            // A user-supplied PYTHONPATH may itself contain multiple entries, so we split it
-            // before re-joining to avoid `join_paths` rejecting the pre-joined string.
-            let pythonpath = append_to_path_list(existing, &import_paths);
-            other_env_vars.insert("PYTHONPATH".to_string(), pythonpath);
-        } else {
-            // Otherwise, we just set it.
-            other_env_vars.insert("PYTHONPATH".to_string(), import_paths);
-        }
+    if !import_paths.is_empty() {
+        debug!(ctx: &ctx, "adding import paths to PYTHONPATH: {:?}", import_paths);
     }
 
     // We insert these checks for cancellation along the way to see if the process was
@@ -207,6 +193,7 @@ async fn inner_execute_local_app(
             secrets,
             params,
             other_env_vars,
+            &import_paths,
         )
         .await?;
 
@@ -230,6 +217,7 @@ async fn inner_execute_local_app(
             &secrets,
             &params,
             &other_env_vars,
+            &import_paths,
         );
 
         // Now we also need to find the program to execute.
@@ -490,6 +478,7 @@ async fn execute_bash_program(
     secrets: HashMap<String, String>,
     params: HashMap<String, String>,
     other_env_vars: HashMap<String, String>,
+    import_paths: &[PathBuf],
 ) -> Result<Child, Error> {
     let bash_path = find_bash().await?;
     debug!(ctx: &ctx, "using bash at {:?}", bash_path);
@@ -509,24 +498,12 @@ async fn execute_bash_program(
             &secrets,
             &params,
             &other_env_vars,
+            import_paths,
         ))
         .kill_on_drop(true)
         .spawn()?;
 
     Ok(child)
-}
-
-/// Appends `new_entry` to a PATH-style list (e.g. PYTHONPATH) that may already contain multiple
-/// entries separated by the platform path separator. The existing value is decomposed with
-/// `split_paths` so that `join_paths` only sees individual entries (which never contain the
-/// separator), making the join infallible.
-fn append_to_path_list(existing: &str, new_entry: &str) -> String {
-    let mut entries: Vec<PathBuf> = env::split_paths(existing).collect();
-    entries.push(PathBuf::from(new_entry));
-    env::join_paths(&entries)
-        .expect("split path entries should never contain the platform path separator")
-        .to_string_lossy()
-        .to_string()
 }
 
 fn make_env_var_key(src: &str) -> String {
@@ -548,6 +525,7 @@ fn make_env_vars(
     secs: &HashMap<String, String>,
     params: &HashMap<String, String>,
     other_env_vars: &HashMap<String, String>,
+    import_paths: &[PathBuf],
 ) -> HashMap<String, String> {
     let mut res = HashMap::new();
 
@@ -568,20 +546,20 @@ fn make_env_vars(
     let added_keys = res.keys().map(|s| &**s).collect::<Vec<&str>>().join(", ");
     debug!(ctx: &ctx, "added keys {}", &added_keys);
 
-    // We also need a PYTHONPATH that is set to the current working directory to help with the
-    // dependency resolution problem at runtime.
-    let pythonpath = cwd.to_string_lossy().to_string();
-    let pythonpath = if let Some(existing) = res.get("PYTHONPATH") {
-        // If we already have a PYTHONPATH, we need to append to it. The existing value may itself
-        // contain multiple entries separated by the platform path separator, so split it before
-        // re-joining — passing a pre-joined string into `join_paths` directly would fail because
-        // it rejects any component containing the separator.
-        append_to_path_list(existing, &pythonpath)
-    } else {
-        // There was no previously set PYTHONPATH, so we just include our current directory.
-        pythonpath
-    };
+    let mut path_entries: Vec<PathBuf> = res
+        .remove("PYTHONPATH")
+        .as_deref()
+        .map(env::split_paths)
+        .into_iter()
+        .flatten()
+        .collect();
+    path_entries.extend(import_paths.iter().cloned());
+    path_entries.push(cwd.clone());
 
+    let pythonpath = env::join_paths(&path_entries)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
     res.insert("PYTHONPATH".to_string(), pythonpath);
 
     // Inject a TOWER_ENVIRONMENT parameter so you know what environment you're running in. Empty

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -177,13 +177,10 @@ async fn inner_execute_local_app(
             .to_string_lossy()
             .to_string();
 
-        if other_env_vars.contains_key("PYTHONPATH") {
-            // If we already have a PYTHONPATH, we need to append to it.
-            let existing = other_env_vars.get("PYTHONPATH").unwrap();
-            let pythonpath = std::env::join_paths(vec![existing, &import_paths])?
-                .to_string_lossy()
-                .to_string();
-
+        if let Some(existing) = other_env_vars.get("PYTHONPATH") {
+            // A user-supplied PYTHONPATH may itself contain multiple entries, so we split it
+            // before re-joining to avoid `join_paths` rejecting the pre-joined string.
+            let pythonpath = append_to_path_list(existing, &import_paths);
             other_env_vars.insert("PYTHONPATH".to_string(), pythonpath);
         } else {
             // Otherwise, we just set it.
@@ -519,6 +516,19 @@ async fn execute_bash_program(
     Ok(child)
 }
 
+/// Appends `new_entry` to a PATH-style list (e.g. PYTHONPATH) that may already contain multiple
+/// entries separated by the platform path separator. The existing value is decomposed with
+/// `split_paths` so that `join_paths` only sees individual entries (which never contain the
+/// separator), making the join infallible.
+fn append_to_path_list(existing: &str, new_entry: &str) -> String {
+    let mut entries: Vec<PathBuf> = env::split_paths(existing).collect();
+    entries.push(PathBuf::from(new_entry));
+    env::join_paths(&entries)
+        .expect("split path entries should never contain the platform path separator")
+        .to_string_lossy()
+        .to_string()
+}
+
 fn make_env_var_key(src: &str) -> String {
     // TODO: We have this special case defined for dltHub, and I'm not sure that we want to...
     if src.starts_with("dlt.") {
@@ -561,11 +571,12 @@ fn make_env_vars(
     // We also need a PYTHONPATH that is set to the current working directory to help with the
     // dependency resolution problem at runtime.
     let pythonpath = cwd.to_string_lossy().to_string();
-    let pythonpath = if res.contains_key("PYTHONPATH") {
-        // If we already have a PYTHONPATH, we need to append to it.
-        let existing = res.get("PYTHONPATH").unwrap();
-        let joined_paths = std::env::join_paths([existing, &pythonpath]).unwrap();
-        joined_paths.to_string_lossy().to_string()
+    let pythonpath = if let Some(existing) = res.get("PYTHONPATH") {
+        // If we already have a PYTHONPATH, we need to append to it. The existing value may itself
+        // contain multiple entries separated by the platform path separator, so split it before
+        // re-joining — passing a pre-joined string into `join_paths` directly would fail because
+        // it rejects any component containing the separator.
+        append_to_path_list(existing, &pythonpath)
     } else {
         // There was no previously set PYTHONPATH, so we just include our current directory.
         pythonpath

--- a/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/Towerfile
+++ b/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/Towerfile
@@ -1,0 +1,7 @@
+[app]
+name = "06-multiple-import-paths"
+script = "./task.py"
+import_paths = [
+    "./lib_a",
+    "./lib_b",
+]

--- a/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/lib_a/mod_a.py
+++ b/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/lib_a/mod_a.py
@@ -1,0 +1,2 @@
+def greet():
+    print("hello from mod_a")

--- a/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/lib_b/mod_b.py
+++ b/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/lib_b/mod_b.py
@@ -1,0 +1,2 @@
+def greet():
+    print("hello from mod_b")

--- a/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/task.py
+++ b/crates/tower-runtime/tests/example-apps/06-multiple-import-paths/task.py
@@ -1,0 +1,5 @@
+import mod_a
+import mod_b
+
+mod_a.greet()
+mod_b.greet()

--- a/crates/tower-runtime/tests/local_test.rs
+++ b/crates/tower-runtime/tests/local_test.rs
@@ -381,3 +381,53 @@ async fn test_abort_on_dependency_installation_failure() {
         }
     }
 }
+
+// Regression test: when a Towerfile declares multiple `import_paths`, the runtime used to panic
+// while building PYTHONPATH because the already-joined value was fed back into
+// `std::env::join_paths`, which rejects components containing the path separator.
+#[tokio::test]
+async fn test_running_app_with_multiple_import_paths() {
+    debug!("Running 06-multiple-import-paths");
+    let dir = get_example_app_dir("06-multiple-import-paths");
+    let package = build_package_from_dir(&dir).await;
+    let (sender, mut receiver) = unbounded_channel();
+
+    let opts = StartOptions {
+        ctx: tower_telemetry::Context::new("runner-id".to_string()),
+        package,
+        output_sender: sender,
+        cwd: None,
+        environment: "local".to_string(),
+        secrets: HashMap::new(),
+        parameters: HashMap::new(),
+        env_vars: HashMap::new(),
+        cache_dir: Some(config::default_cache_dir()),
+    };
+
+    let app = LocalApp::start(opts)
+        .await
+        .expect("Failed to start app with multiple import_paths");
+
+    let mut outputs = Vec::new();
+    while let Some(output) = receiver.recv().await {
+        outputs.push(output.line);
+    }
+
+    assert!(
+        outputs.iter().any(|line| line.contains("hello from mod_a")),
+        "expected output from lib_a/mod_a; got {:?}",
+        outputs
+    );
+    assert!(
+        outputs.iter().any(|line| line.contains("hello from mod_b")),
+        "expected output from lib_b/mod_b; got {:?}",
+        outputs
+    );
+
+    let status = app.status().await.expect("Failed to get app status");
+    assert!(
+        status == Status::Exited,
+        "App should have exited cleanly, got {:?}",
+        status
+    );
+}


### PR DESCRIPTION
Running `tower run --local` or `tower run` in a remote environment against an app whose Towerfile declares two or more `import_paths` panicked the runtime:

```
thread 'tokio-runtime-worker' panicked at crates/tower-runtime/src/local.rs:
called `Result::unwrap()` on an `Err` value: JoinPathsError
Oh no! Your local run crashed with exit code: -1
```

The issue is that in `crates/tower-runtime/src/local.rs`, `PYTHONPATH` was built in two stages:

1. The Towerfile's `import_paths` were joined via `std::env::join_paths` into a single colon-separated string and stored in the env map under `PYTHONPATH`.
2. Later, `make_env_vars` appended the working directory by calling `std::env::join_paths([existing_pythonpath, cwd]).unwrap()`.

`join_paths` rejects any component that already contains the platform path separator, so step 2 failed with `JoinPathsError` and the `unwrap()` panicked. The same shape of bug existed at the earlier append site for user-supplied `PYTHONPATH` env vars.

## The fix

import_paths is now threaded through to make_env_vars as a &[PathBuf], and make_env_vars composes the final PYTHONPATH in a single env::join_paths call over (existing entries split with split_paths) + import_paths + cwd. No more round-tripping a joined string back through join_paths, and no intermediate helper.

As a defense-in-depth measure, Towerfile::from_toml now also rejects import_paths entries that are empty or contain :/;, surfacing an InvalidTowerfile error instead of letting bad input fail deep inside the runtime.

A regression test plus a new 06-multiple-import-paths example app exercise the multi-import-path path, and the original repro now runs cleanly.