### PR TITLE
[TOW-2007] Runtime as the source of start and end times

### DIFF
--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -30,38 +30,62 @@ trait PaginatedResponse {
 
 impl PaginatedResponse for tower_api::models::ListAppsResponse {
     type Item = tower_api::models::AppSummary;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.apps }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.apps
+    }
 }
 
 impl PaginatedResponse for tower_api::models::ListTeamsResponse {
     type Item = tower_api::models::Team;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.teams }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.teams
+    }
 }
 
 impl PaginatedResponse for tower_api::models::ListSecretsResponse {
     type Item = tower_api::models::Secret;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.secrets }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.secrets
+    }
 }
 
 impl PaginatedResponse for tower_api::models::ListCatalogsResponse {
     type Item = tower_api::models::Catalog;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.catalogs }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.catalogs
+    }
 }
 
 impl PaginatedResponse for tower_api::models::ListEnvironmentsResponse {
     type Item = tower_api::models::Environment;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.environments }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.environments
+    }
 }
 
 impl PaginatedResponse for tower_api::models::ListSchedulesResponse {
     type Item = tower_api::models::Schedule;
-    fn pagination(&self) -> &Pagination { &self.pages }
-    fn into_items(self) -> Vec<Self::Item> { self.schedules }
+    fn pagination(&self) -> &Pagination {
+        &self.pages
+    }
+    fn into_items(self) -> Vec<Self::Item> {
+        self.schedules
+    }
 }
 
 /// Fetches pages from a paginated API endpoint, honoring the caller's
@@ -375,8 +399,7 @@ pub async fn list_secrets(
     config: &Config,
     env: &str,
     all: bool,
-) -> Result<Vec<tower_api::models::Secret>, Error<tower_api::apis::default_api::ListSecretsError>>
-{
+) -> Result<Vec<tower_api::models::Secret>, Error<tower_api::apis::default_api::ListSecretsError>> {
     let api_config: configuration::Configuration = config.into();
     let env = env.to_string();
 

--- a/crates/tower-cmd/src/apps.rs
+++ b/crates/tower-cmd/src/apps.rs
@@ -833,9 +833,7 @@ mod tests {
 
     #[test]
     fn list_defaults_to_no_environment_filter() {
-        let matches = apps_cmd()
-            .try_get_matches_from(["apps", "list"])
-            .unwrap();
+        let matches = apps_cmd().try_get_matches_from(["apps", "list"]).unwrap();
         let (_, list_args) = matches.subcommand().unwrap();
 
         assert_eq!(list_args.get_one::<String>("environment"), None);
@@ -849,7 +847,9 @@ mod tests {
         let (_, list_args) = matches.subcommand().unwrap();
 
         assert_eq!(
-            list_args.get_one::<String>("environment").map(|s| s.as_str()),
+            list_args
+                .get_one::<String>("environment")
+                .map(|s| s.as_str()),
             Some("production")
         );
     }

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -713,22 +713,22 @@ async fn monitor_cli_status(
         );
 
         match handle.lock().await.status().await {
-            Ok(status) => {
+            Ok(exec_status) => {
                 // We reset the error count to indicate that we can intermittently get statuses.
                 err_count = 0;
 
-                match status {
+                match exec_status.status {
                     Status::Exited => {
                         debug!("Run exited cleanly, stopping status monitoring");
-                        return status;
+                        return exec_status.status;
                     }
                     Status::Crashed { .. } => {
                         debug!("Run crashed, stopping status monitoring");
-                        return status;
+                        return exec_status.status;
                     }
                     Status::Failed { .. } => {
                         debug!("Run failed at platform layer, stopping status monitoring");
-                        return status;
+                        return exec_status.status;
                     }
                     _ => {
                         debug!("Handle status: other, continuing to monitor");

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -716,19 +716,20 @@ async fn monitor_cli_status(
             Ok(exec_status) => {
                 // We reset the error count to indicate that we can intermittently get statuses.
                 err_count = 0;
+                let status = exec_status.status;
 
-                match exec_status.status {
+                match status {
                     Status::Exited => {
                         debug!("Run exited cleanly, stopping status monitoring");
-                        return exec_status.status;
+                        return status;
                     }
                     Status::Crashed { .. } => {
                         debug!("Run crashed, stopping status monitoring");
-                        return exec_status.status;
+                        return status;
                     }
                     Status::Failed { .. } => {
                         debug!("Run failed at platform layer, stopping status monitoring");
-                        return exec_status.status;
+                        return status;
                     }
                     _ => {
                         debug!("Handle status: other, continuing to monitor");

--- a/crates/tower-cmd/src/teams.rs
+++ b/crates/tower-cmd/src/teams.rs
@@ -60,10 +60,7 @@ async fn do_list_via_api(config: &Config) {
 
     let headers = vec!["Name".to_string()];
 
-    let teams_data: Vec<Vec<String>> = teams
-        .iter()
-        .map(|team| vec![team.name.clone()])
-        .collect();
+    let teams_data: Vec<Vec<String>> = teams.iter().map(|team| vec![team.name.clone()]).collect();
 
     output::newline();
     output::table(headers, teams_data, None::<&Vec<config::Team>>);

--- a/crates/tower-runtime/src/execution.rs
+++ b/crates/tower-runtime/src/execution.rs
@@ -5,6 +5,7 @@
 //! Kubernetes pods, etc.) through a uniform interface.
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::io::AsyncRead;
@@ -198,14 +199,37 @@ pub struct BackendCapabilities {
 // Execution Handle Trait
 // ============================================================================
 
+/// Result of querying execution status, including optional timing and
+/// backend-specific metadata. The metadata map allows backends to surface
+/// arbitrary key-value data (e.g. node_type, scheduling_latency_ms) without
+/// requiring trait changes.
+#[derive(Clone, Debug)]
+pub struct ExecutionStatus {
+    pub status: Status,
+    pub started_at: Option<DateTime<Utc>>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl From<Status> for ExecutionStatus {
+    fn from(status: Status) -> Self {
+        Self {
+            status,
+            started_at: None,
+            ended_at: None,
+            metadata: HashMap::new(),
+        }
+    }
+}
+
 /// ExecutionHandle represents a running execution
 #[async_trait]
 pub trait ExecutionHandle: Send + Sync {
     /// Get a unique identifier for this execution
     fn id(&self) -> &str;
 
-    /// Get current execution status
-    async fn status(&self) -> Result<Status, Error>;
+    /// Get current execution status with optional timing metadata
+    async fn status(&self) -> Result<ExecutionStatus, Error>;
 
     /// Subscribe to log stream
     async fn logs(&self) -> Result<OutputReceiver, Error>;

--- a/crates/tower-runtime/src/lib.rs
+++ b/crates/tower-runtime/src/lib.rs
@@ -83,10 +83,7 @@ impl Status {
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
-            Status::Exited
-                | Status::Crashed { .. }
-                | Status::Cancelled
-                | Status::Failed(_)
+            Status::Exited | Status::Crashed { .. } | Status::Cancelled | Status::Failed(_)
         )
     }
 }

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -303,7 +303,8 @@ async fn inner_execute_local_app(
                 }
             }
             Ok(child) => {
-                let mut res = run_setup_child(&ctx, &cancel_token, &opts.output_sender, child).await;
+                let mut res =
+                    run_setup_child(&ctx, &cancel_token, &opts.output_sender, child).await;
 
                 // If sync was cancelled, don't bother retrying — bail out
                 // cleanly so the receiver sees `Status::Cancelled` instead of
@@ -328,7 +329,8 @@ async fn inner_execute_local_app(
                     let retry_child = uv
                         .sync_with_legacy_setuptools_pin(&working_dir, &env_vars)
                         .await?;
-                    res = run_setup_child(&ctx, &cancel_token, &opts.output_sender, retry_child).await;
+                    res = run_setup_child(&ctx, &cancel_token, &opts.output_sender, retry_child)
+                        .await;
                     if cancel_token.is_cancelled() {
                         return Err(Error::Cancelled);
                     }
@@ -419,7 +421,9 @@ impl App for LocalApp {
                 Ok(Ok(code)) => AppCompletion::Exit(code),
                 Ok(Err(Error::Cancelled)) => AppCompletion::Cancelled,
                 Ok(Err(e)) => AppCompletion::Failed(AppFailure::Runtime(e)),
-                Err(panic) => AppCompletion::Failed(AppFailure::Panic(panic_payload_message(&panic))),
+                Err(panic) => {
+                    AppCompletion::Failed(AppFailure::Panic(panic_payload_message(&panic)))
+                }
             };
             let _ = sx.send(completion);
         });

--- a/crates/tower-runtime/src/subprocess.rs
+++ b/crates/tower-runtime/src/subprocess.rs
@@ -247,12 +247,12 @@ impl ExecutionHandle for SubprocessHandle {
 
     async fn wait_for_completion(&self) -> Result<Status, Error> {
         loop {
-            let exec_status = self.status().await?;
-            match exec_status.status {
+            let status = self.status().await?.status;
+            match status {
                 Status::None | Status::Running => {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
-                _ => return Ok(exec_status.status),
+                _ => return Ok(status),
             }
         }
     }

--- a/crates/tower-runtime/src/subprocess.rs
+++ b/crates/tower-runtime/src/subprocess.rs
@@ -4,7 +4,7 @@ use crate::auto_cleanup;
 use crate::errors::Error;
 use crate::execution::{
     BackendCapabilities, CacheBackend, ExecutionBackend, ExecutionHandle, ExecutionSpec,
-    ServiceEndpoint,
+    ExecutionStatus, ServiceEndpoint,
 };
 use crate::local::LocalApp;
 use crate::{App, OutputReceiver, StartOptions, Status};
@@ -212,9 +212,9 @@ impl ExecutionHandle for SubprocessHandle {
         &self.id
     }
 
-    async fn status(&self) -> Result<Status, Error> {
+    async fn status(&self) -> Result<ExecutionStatus, Error> {
         let app = self.app.lock().await;
-        app.status().await
+        Ok(app.status().await?.into())
     }
 
     async fn logs(&self) -> Result<OutputReceiver, Error> {
@@ -247,12 +247,12 @@ impl ExecutionHandle for SubprocessHandle {
 
     async fn wait_for_completion(&self) -> Result<Status, Error> {
         loop {
-            let status = self.status().await?;
-            match status {
+            let exec_status = self.status().await?;
+            match exec_status.status {
                 Status::None | Status::Running => {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
-                _ => return Ok(status),
+                _ => return Ok(exec_status.status),
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution status now returns richer information including optional started and ended timestamps, plus metadata details.

* **Refactor**
  * Internal code structure improvements across multiple modules for maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tower/tower-cli/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->