### PR TITLE
fix: honor TOWER_API_KEY in deploy upload and log stream paths

### DIFF
--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -673,8 +673,16 @@ pub async fn stream_run_logs(
         builder = builder.header(reqwest::header::USER_AGENT, user_agent.clone());
     }
 
+    // Mirrors the generated tower-api client: prefer a bearer token (interactive session),
+    // otherwise fall back to the API key header set when TOWER_API_KEY is configured.
     if let Some(ref token) = api_config.bearer_access_token {
         builder = builder.bearer_auth(token.to_owned());
+    } else if let Some(ref apikey) = api_config.api_key {
+        let value = match &apikey.prefix {
+            Some(prefix) => format!("{} {}", prefix, apikey.key),
+            None => apikey.key.clone(),
+        };
+        builder = builder.header("X-API-Key", value);
     };
 
     // Now let's try to open the event source with the server.

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -57,9 +57,17 @@ pub async fn upload_file_with_progress(
         .header("Content-Encoding", "gzip")
         .body(Body::wrap_stream(progress_stream));
 
-    // Add authorization if available
+    // Add authorization if available. Mirrors the generated tower-api client: prefer a
+    // bearer token (interactive session), otherwise fall back to the API key header set
+    // when TOWER_API_KEY is configured.
     if let Some(token) = &api_config.bearer_access_token {
         req = req.header("Authorization", format!("Bearer {}", token));
+    } else if let Some(apikey) = &api_config.api_key {
+        let value = match &apikey.prefix {
+            Some(prefix) => format!("{} {}", prefix, apikey.key),
+            None => apikey.key.clone(),
+        };
+        req = req.header("X-API-Key", value);
     }
 
     // Send the request


### PR DESCRIPTION
Bit of an oversight on our part: Users should be able to user `TOWER_API_KEY` for doing deployments, too! Because this goes through a separate client, it wasn't properly implemented.