### PR TITLE
fix(tower-runtime): preserve error details in SpawnFailed and PackageUnpackFailed

### DIFF
--- a/crates/tower-runtime/src/errors.rs
+++ b/crates/tower-runtime/src/errors.rs
@@ -5,8 +5,8 @@ pub enum Error {
     #[snafu(display("failed to RPC server"))]
     RuntimeStartFailed,
 
-    #[snafu(display("spawning process"))]
-    SpawnFailed,
+    #[snafu(display("spawning process: {detail}"))]
+    SpawnFailed { detail: String },
 
     #[snafu(display("no app running"))]
     NoRunningApp,
@@ -23,8 +23,8 @@ pub enum Error {
     #[snafu(display("package create failed"))]
     PackageCreateFailed,
 
-    #[snafu(display("package unpack failed"))]
-    PackageUnpackFailed,
+    #[snafu(display("package unpack failed: {detail}"))]
+    PackageUnpackFailed { detail: String },
 
     #[snafu(display("container already initialized"))]
     AlreadyInitialized,
@@ -79,8 +79,10 @@ pub enum Error {
 }
 
 impl From<std::io::Error> for Error {
-    fn from(_: std::io::Error) -> Self {
-        Error::SpawnFailed
+    fn from(err: std::io::Error) -> Self {
+        Error::SpawnFailed {
+            detail: err.to_string(),
+        }
     }
 }
 
@@ -93,19 +95,18 @@ impl From<std::env::JoinPathsError> for Error {
 impl From<tower_uv::Error> for Error {
     fn from(err: tower_uv::Error) -> Self {
         match err {
-            tower_uv::Error::IoError(_) => Error::SpawnFailed,
-            tower_uv::Error::NotFound(_) => Error::SpawnFailed,
-            tower_uv::Error::PermissionDenied(_) => Error::SpawnFailed,
-            tower_uv::Error::Other(_) => Error::SpawnFailed,
-            tower_uv::Error::MissingPyprojectToml => Error::SpawnFailed,
-            tower_uv::Error::InvalidUv => Error::SpawnFailed,
             tower_uv::Error::UnsupportedPlatform => Error::UnsupportedPlatform,
+            other => Error::SpawnFailed {
+                detail: other.to_string(),
+            },
         }
     }
 }
 
 impl From<tower_package::Error> for Error {
-    fn from(_: tower_package::Error) -> Self {
-        Error::PackageUnpackFailed
+    fn from(err: tower_package::Error) -> Self {
+        Error::PackageUnpackFailed {
+            detail: err.to_string(),
+        }
     }
 }

--- a/crates/tower-runtime/src/subprocess.rs
+++ b/crates/tower-runtime/src/subprocess.rs
@@ -81,7 +81,9 @@ impl SubprocessBackend {
         package.tmp_dir = Some(temp_dir);
         package.unpack().await.map_err(|e| {
             error!(ctx: ctx, "Failed to unpack package: {:?}", e);
-            Error::PackageUnpackFailed
+            Error::PackageUnpackFailed {
+                detail: format!("{:?}", e),
+            }
         })?;
 
         info!(ctx: ctx, "Successfully unpacked package");
@@ -124,7 +126,9 @@ impl ExecutionBackend for SubprocessBackend {
         let unpacked_path = package
             .unpacked_path
             .clone()
-            .ok_or(Error::PackageUnpackFailed)?;
+            .ok_or(Error::PackageUnpackFailed {
+                detail: "no unpacked_path after unpack".to_string(),
+            })?;
 
         // Extract tmp_dir from package for cleanup tracking
         // We need to keep this alive until execution completes

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -26,6 +26,20 @@ pub enum Error {
     UnsupportedPlatform,
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::IoError(e) => write!(f, "IO error: {}", e),
+            Error::NotFound(msg) => write!(f, "not found: {}", msg),
+            Error::PermissionDenied(msg) => write!(f, "permission denied: {}", msg),
+            Error::Other(msg) => write!(f, "{}", msg),
+            Error::MissingPyprojectToml => write!(f, "missing pyproject.toml"),
+            Error::InvalidUv => write!(f, "invalid uv installation"),
+            Error::UnsupportedPlatform => write!(f, "unsupported platform"),
+        }
+    }
+}
+
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         // Convert std::fs::Error to your custom Error type


### PR DESCRIPTION
## Summary
- Add `detail: String` field to `Error::SpawnFailed` and `Error::PackageUnpackFailed` so the root cause (IO error, missing uv, permission denied, etc.) flows through to termination logs and trace spans
- Add `Display` impl for `tower_uv::Error`
- Previously all `tower_uv::Error` variants were mapped to a bare `Error::SpawnFailed` with no context, making production `spawn_failed` errors impossible to diagnose without pod-level access

## Context

Investigating TOW-2151/TOW-2160 (WaiterClosed) and recent `spawn_failed` errors on May 31, we found that while the structured `AppCompletion::Failed` pipeline (from #274) correctly surfaces the error kind, the actual error *message* was always just "SpawnFailed" because the `From<tower_uv::Error>` impl discarded the inner detail.

After this change, termination logs and trace spans will show messages like:
- `spawning process: not found: uv binary not found in PATH`
- `spawning process: IO error: No such file or directory (os error 2)`
- `spawning process: permission denied: /app/.venv/bin/python`
- `package unpack failed: InvalidManifest`

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [ ] Deploy to staging and trigger a run with a broken pyproject.toml to verify the detail appears in traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages with detailed context for spawn failures and package operations, helping users better understand what went wrong during runtime execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->