### PR TITLE
fix: add name field to generated SKILL.md frontmatter

### DIFF
--- a/crates/tower-cmd/src/skill.rs
+++ b/crates/tower-cmd/src/skill.rs
@@ -99,6 +99,7 @@ fn append_command(out: &mut String, cmd: &Command, path: &[&str], depth: usize) 
 }
 
 const WORKFLOW_HEADER: &str = r#"---
+name: tower
 description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
 ---
 

--- a/skills/tower/SKILL.md
+++ b/skills/tower/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: tower
 description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
 ---
 


### PR DESCRIPTION
`npx skills add tower/tower-cli` reported "No skills found" even though `skills/tower/SKILL.md` exists. The installer requires both `name` and `description` in the frontmatter, and ours had only `description`.

This adds `name: tower` to the generator's frontmatter header in `skill.rs`, so every future `tower skill generate` emits it, and regenerates the checked-in `skills/tower/SKILL.md` to match. The generated body is unchanged — the diff is the single added line.