### PR TITLE
chore: bump version to v0.3.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "base64",
  "chrono",
@@ -631,7 +631,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "pem",
  "rsa",
@@ -3586,7 +3586,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "config",
  "pyo3",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "tower-api"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "reqwest",
  "serde",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cmd"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "axum",
  "bytes",
@@ -3697,7 +3697,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-package"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-compression",
  "flate2",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "tower-runtime"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower-telemetry"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "tracing",
  "tracing-appender",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "tower-uv"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "tower-version"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.63"
+version = "0.3.64"
 description = "Tower is the best way to host Python data apps in production"
 rust-version = "1.81"
 authors = ["Brad Heller <brad@tower.dev>", "Ben Lovell <ben@tower.dev>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 description = "Tower CLI and runtime environment for Tower."
 authors = [{ name = "Tower Computing Inc.", email = "brad@tower.dev" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2642,7 +2642,7 @@ wheels = [
 
 [[package]]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Bumps the workspace and Python package version from 0.3.63 to 0.3.64, with the lockfiles regenerated to match.