### PR TITLE
Release v0.3.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "base64",
  "chrono",
@@ -631,7 +631,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "pem",
  "rsa",
@@ -3586,7 +3586,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "config",
  "pyo3",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "tower-api"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "reqwest",
  "serde",
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cmd"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "axum",
  "bytes",
@@ -3697,7 +3697,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-package"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-compression",
  "flate2",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "tower-runtime"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3745,7 +3745,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower-telemetry"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "tracing",
  "tracing-appender",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "tower-uv"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "tower-version"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.63"
+version = "0.3.64"
 description = "Tower is the best way to host Python data apps in production"
 rust-version = "1.81"
 authors = ["Brad Heller <brad@tower.dev>", "Ben Lovell <ben@tower.dev>"]

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -182,6 +182,7 @@ where
 
     env_vars.insert("TOWER_JWT".to_string(), session.token.jwt.to_string());
     env_vars.insert("TOWER__RUNTIME__IS_LOCAL".to_string(), "true".to_string());
+    env_vars.insert("TOWER_ENVIRONMENT".to_string(), env.to_string());
 
     // Load the Towerfile
     let towerfile_path = path.join("Towerfile");

--- a/crates/tower-cmd/src/skill.rs
+++ b/crates/tower-cmd/src/skill.rs
@@ -99,6 +99,7 @@ fn append_command(out: &mut String, cmd: &Command, path: &[&str], depth: usize) 
 }
 
 const WORKFLOW_HEADER: &str = r#"---
+name: tower
 description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
 ---
 

--- a/crates/tower-runtime/src/local.rs
+++ b/crates/tower-runtime/src/local.rs
@@ -146,7 +146,6 @@ async fn inner_execute_local_app(
 ) -> Result<i32, Error> {
     let ctx = opts.ctx.clone();
     let package = opts.package;
-    let environment = opts.environment;
     let package_path = package.unpacked_path.clone().unwrap().to_path_buf();
 
     // set for later on.
@@ -186,7 +185,6 @@ async fn inner_execute_local_app(
     if is_bash_package(&package) {
         let child = execute_bash_program(
             &ctx,
-            &environment,
             working_dir,
             package_path,
             &manifest,
@@ -212,7 +210,6 @@ async fn inner_execute_local_app(
         let uv = Uv::new(opts.cache_dir, protected_mode).await?;
         let env_vars = make_env_vars(
             &ctx,
-            &environment,
             &package_path,
             &secrets,
             &params,
@@ -475,7 +472,6 @@ impl App for LocalApp {
 
 async fn execute_bash_program(
     ctx: &tower_telemetry::Context,
-    env: &str,
     cwd: PathBuf,
     package_path: PathBuf,
     manifest: &Manifest,
@@ -497,7 +493,6 @@ async fn execute_bash_program(
         .stderr(Stdio::piped())
         .envs(make_env_vars(
             &ctx,
-            env,
             &cwd,
             &secrets,
             &params,
@@ -524,7 +519,6 @@ fn make_env_var_key(src: &str) -> String {
 
 fn make_env_vars(
     ctx: &tower_telemetry::Context,
-    env: &str,
     cwd: &PathBuf,
     secs: &HashMap<String, String>,
     params: &HashMap<String, String>,
@@ -565,14 +559,6 @@ fn make_env_vars(
         .to_string_lossy()
         .to_string();
     res.insert("PYTHONPATH".to_string(), pythonpath);
-
-    // Inject a TOWER_ENVIRONMENT parameter so you know what environment you're running in. Empty
-    // environment is "default" by default.
-    if env.is_empty() {
-        res.insert("TOWER_ENVIRONMENT".to_string(), "default".to_string());
-    } else {
-        res.insert("TOWER_ENVIRONMENT".to_string(), env.to_string());
-    }
 
     res.insert("PYTHONUNBUFFERED".to_string(), "x".to_string());
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 description = "Tower CLI and runtime environment for Tower."
 authors = [{ name = "Tower Computing Inc.", email = "brad@tower.dev" }]
 readme = "README.md"

--- a/skills/tower/SKILL.md
+++ b/skills/tower/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: tower
 description: Use Tower to build, run, and deploy Python data apps, pipelines, and AI agents. Covers MCP tools, Towerfile setup, local development, cloud deployment, scheduling, and secrets management.
 ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -2642,7 +2642,7 @@ wheels = [
 
 [[package]]
 name = "tower"
-version = "0.3.63"
+version = "0.3.64"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Promotes develop to main for the v0.3.64 release.

Included:
- #289 — make `TOWER_ENVIRONMENT` ordinary passthrough in local runs
- #287 — add `name` field to generated `SKILL.md` frontmatter
- #290 — bump version to v0.3.64

Merge after #290 has landed on develop so the version bump ships with this release.