### PR TITLE
feat(cli+sdk): Tower Storage from the CLI — credential vending & connection snippets

### DIFF
--- a/crates/tower-cmd/src/api.rs
+++ b/crates/tower-cmd/src/api.rs
@@ -350,21 +350,24 @@ pub async fn list_catalogs(
     config: &Config,
     env: &str,
     all: bool,
+    catalog_type: Option<&str>,
 ) -> Result<Vec<tower_api::models::Catalog>, Error<tower_api::apis::default_api::ListCatalogsError>>
 {
     let api_config: configuration::Configuration = config.into();
     let env = env.to_string();
+    let catalog_type = catalog_type.map(str::to_string);
 
     fetch_all_pages(config, |page, page_size| {
         let api_config = &api_config;
         let env = &env;
+        let catalog_type = &catalog_type;
         async move {
             let params = tower_api::apis::default_api::ListCatalogsParams {
                 environment: Some(env.to_string()),
                 all: Some(all),
                 page: Some(page),
                 page_size: Some(page_size),
-                r#type: None,
+                r#type: catalog_type.clone(),
             };
             unwrap_api_response(tower_api::apis::default_api::list_catalogs(
                 api_config, params,
@@ -372,6 +375,33 @@ pub async fn list_catalogs(
             .await
         }
     })
+    .await
+}
+
+pub async fn vend_catalog_credentials(
+    config: &Config,
+    name: &str,
+    env: &str,
+    mode: tower_api::models::vend_catalog_credentials_body::Mode,
+) -> Result<
+    tower_api::models::VendCatalogCredentialsResponse,
+    Error<tower_api::apis::default_api::VendCatalogCredentialsError>,
+> {
+    let api_config = config.into();
+
+    let params = tower_api::apis::default_api::VendCatalogCredentialsParams {
+        name: name.to_string(),
+        environment: Some(env.to_string()),
+        vend_catalog_credentials_body: tower_api::models::VendCatalogCredentialsBody {
+            schema: None,
+            mode: Some(mode),
+        },
+    };
+
+    unwrap_api_response_redacted(tower_api::apis::default_api::vend_catalog_credentials(
+        &api_config,
+        params,
+    ))
     .await
 }
 
@@ -724,6 +754,27 @@ where
     T: ResponseEntity,
     T::Data: serde::de::DeserializeOwned,
 {
+    unwrap_api_response_inner(api_call, false).await
+}
+
+async fn unwrap_api_response_redacted<T, F, V>(api_call: F) -> Result<T::Data, Error<V>>
+where
+    F: std::future::Future<Output = Result<ResponseContent<T>, Error<V>>>,
+    T: ResponseEntity,
+    T::Data: serde::de::DeserializeOwned,
+{
+    unwrap_api_response_inner(api_call, true).await
+}
+
+async fn unwrap_api_response_inner<T, F, V>(
+    api_call: F,
+    redact_success_content: bool,
+) -> Result<T::Data, Error<V>>
+where
+    F: std::future::Future<Output = Result<ResponseContent<T>, Error<V>>>,
+    T: ResponseEntity,
+    T::Data: serde::de::DeserializeOwned,
+{
     match api_call.await {
         Ok(response) => {
             if response.status.is_client_error() || response.status.is_server_error() {
@@ -736,22 +787,32 @@ where
             }
 
             debug!("tower trace ID: {}", response.tower_trace_id);
-            debug!("Response from server: {}", response.content);
+            if redact_success_content {
+                debug!("Response from server: <redacted>");
+            } else {
+                debug!("Response from server: {}", response.content);
+            }
 
             if let Some(entity) = response.entity {
                 if let Some(data) = entity.extract_data() {
                     Ok(data)
                 } else {
-                    let truncated = if response.content.len() > 500 {
+                    let truncated = if redact_success_content {
+                        "<redacted>".to_string()
+                    } else if response.content.len() > 500 {
                         format!("{}...(truncated)", &response.content[..500])
                     } else {
                         response.content.clone()
                     };
                     // Try explicit deserialization to get the actual error message
-                    let deser_error = serde_json::from_str::<T::Data>(&response.content)
-                        .err()
-                        .map(|e| format!(" Deserialization error: {}", e))
-                        .unwrap_or_default();
+                    let deser_error = if redact_success_content {
+                        String::new()
+                    } else {
+                        serde_json::from_str::<T::Data>(&response.content)
+                            .err()
+                            .map(|e| format!(" Deserialization error: {}", e))
+                            .unwrap_or_default()
+                    };
                     debug!(
                         "Failed to extract data from API response:{} Content: {}",
                         deser_error, truncated
@@ -830,6 +891,17 @@ impl ResponseEntity for tower_api::apis::default_api::ListCatalogsSuccess {
 
 impl ResponseEntity for tower_api::apis::default_api::DescribeCatalogSuccess {
     type Data = tower_api::models::DescribeCatalogResponse;
+
+    fn extract_data(self) -> Option<Self::Data> {
+        match self {
+            Self::Status200(data) => Some(data),
+            Self::UnknownValue(_) => None,
+        }
+    }
+}
+
+impl ResponseEntity for tower_api::apis::default_api::VendCatalogCredentialsSuccess {
+    type Data = tower_api::models::VendCatalogCredentialsResponse;
 
     fn extract_data(self) -> Option<Self::Data> {
         match self {
@@ -1338,6 +1410,51 @@ impl ResponseEntity for tower_api::apis::default_api::CancelRunSuccess {
         match self {
             Self::Status200(data) => Some(data),
             Self::UnknownValue(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{unwrap_api_response_redacted, ResponseEntity};
+    use http::StatusCode;
+    use tower_api::apis::{Error, ResponseContent};
+
+    enum SensitiveSuccess {
+        UnknownValue,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct SensitiveData {
+        _value: String,
+    }
+
+    impl ResponseEntity for SensitiveSuccess {
+        type Data = SensitiveData;
+
+        fn extract_data(self) -> Option<Self::Data> {
+            None
+        }
+    }
+
+    #[tokio::test]
+    async fn redacted_unwrap_does_not_return_sensitive_response_body() {
+        let response = ResponseContent {
+            tower_trace_id: "trace-id".to_string(),
+            status: StatusCode::OK,
+            content: r#"{"credentials":{"oauth_token":"secret-token"}}"#.to_string(),
+            entity: Some(SensitiveSuccess::UnknownValue),
+        };
+
+        let result =
+            unwrap_api_response_redacted::<SensitiveSuccess, _, ()>(async { Ok(response) }).await;
+
+        match result {
+            Err(Error::ResponseError(response)) => {
+                assert!(!response.content.contains("secret-token"));
+                assert!(response.content.contains("<redacted>"));
+            }
+            _ => panic!("expected redacted response error"),
         }
     }
 }

--- a/crates/tower-cmd/src/catalogs.rs
+++ b/crates/tower-cmd/src/catalogs.rs
@@ -1,7 +1,9 @@
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use colored::Colorize;
 use config::Config;
-use tower_api::models::{vend_catalog_credentials_body, CatalogCredentials};
+use tower_api::models::{
+    vend_catalog_credentials_body, CatalogCredentials, DescribeCatalogResponse,
+};
 
 use crate::{api, output, util::cmd};
 
@@ -162,17 +164,16 @@ pub async fn do_credentials(config: Config, args: &ArgMatches) {
     )
     .await;
 
-    output::render_human_or_json(&response, || {
-        print_credentials(
-            name,
-            &env,
-            mode,
-            config.tower_url.as_str(),
-            &response.credentials,
-            format,
-            show_token,
-        );
-    });
+    let human = credentials_text(
+        name,
+        &env,
+        mode,
+        config.tower_url.as_str(),
+        &response.credentials,
+        format,
+        show_token,
+    );
+    output::text(&human, &response);
 }
 
 pub async fn do_show(config: Config, args: &ArgMatches) {
@@ -183,35 +184,8 @@ pub async fn do_show(config: Config, args: &ArgMatches) {
 
     match api::describe_catalog(&config, name, &env).await {
         Ok(response) => {
-            output::render_human_or_json(&response, || {
-                let catalog = &response.catalog;
-
-                output::detail("Catalog", &catalog.name);
-                output::detail("Type", &catalog.r#type);
-                output::detail("Environment", &catalog.environment);
-
-                if !catalog.properties.is_empty() {
-                    output::newline();
-                    output::header("Properties");
-
-                    let headers = vec!["Name", "Runtime Var", "Preview"]
-                        .into_iter()
-                        .map(str::to_string)
-                        .collect();
-                    let data = catalog
-                        .properties
-                        .iter()
-                        .map(|prop| {
-                            vec![
-                                prop.name.clone(),
-                                prop.environment_variable.clone().unwrap_or_default(),
-                                prop.preview.dimmed().to_string(),
-                            ]
-                        })
-                        .collect();
-                    output::table(headers, data, Some(&response));
-                }
-            });
+            let human = catalog_details_text(&response);
+            output::text(&human, &response);
         }
         Err(err) => output::tower_error_and_die(err, "Fetching catalog details failed"),
     }
@@ -250,7 +224,48 @@ fn token_export_command(name: &str, environment: &str, mode: &str, tower_url: &s
     )
 }
 
-fn print_credentials(
+fn detail_line(label: &str, value: &str) -> String {
+    format!("{} {}\n", format!("{}:", label).bold().green(), value)
+}
+
+fn header_line(text: &str) -> String {
+    format!("{}\n", text.bold().green())
+}
+
+fn catalog_details_text(response: &DescribeCatalogResponse) -> String {
+    let catalog = &response.catalog;
+    let mut out = String::new();
+
+    out.push_str(&detail_line("Catalog", &catalog.name));
+    out.push_str(&detail_line("Type", &catalog.r#type));
+    out.push_str(&detail_line("Environment", &catalog.environment));
+
+    if !catalog.properties.is_empty() {
+        out.push('\n');
+        out.push_str(&header_line("Properties"));
+
+        let headers = vec!["Name", "Runtime Var", "Preview"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let data = catalog
+            .properties
+            .iter()
+            .map(|prop| {
+                vec![
+                    prop.name.clone(),
+                    prop.environment_variable.clone().unwrap_or_default(),
+                    prop.preview.dimmed().to_string(),
+                ]
+            })
+            .collect();
+        out.push_str(&output::table_text(headers, data));
+    }
+
+    out
+}
+
+fn credentials_text(
     name: &str,
     environment: &str,
     mode: &str,
@@ -258,32 +273,42 @@ fn print_credentials(
     credentials: &CatalogCredentials,
     format: &str,
     show_token: bool,
-) {
-    output::detail("Catalog", name);
-    output::detail("Mode", &credentials.mode);
-    output::detail("Expires", &credentials.expires_at);
+) -> String {
+    let mut out = String::new();
+
+    out.push_str(&detail_line("Catalog", name));
+    out.push_str(&detail_line("Mode", &credentials.mode));
+    out.push_str(&detail_line("Expires", &credentials.expires_at));
     if show_token {
-        output::detail("Token", &credentials.oauth_token);
+        out.push_str(&detail_line("Token", &credentials.oauth_token));
     } else {
-        output::detail("Token", "not printed; snippets read $TOWER_CATALOG_TOKEN");
+        out.push_str(&detail_line(
+            "Token",
+            "not printed; snippets read $TOWER_CATALOG_TOKEN",
+        ));
     }
-    output::write(&output::paragraph(
+    out.push_str(&output::paragraph(
         "These credentials are short-lived and intended for ad-hoc development use.",
     ));
-    output::newline();
+    out.push('\n');
 
     if !show_token {
-        output::newline();
-        output::header("Shell setup");
-        output::write(token_export_command(name, environment, mode, tower_url).as_str());
+        out.push('\n');
+        out.push_str(&header_line("Shell setup"));
+        out.push_str(token_export_command(name, environment, mode, tower_url).as_str());
     }
 
     for snippet in snippets(name, credentials, format, show_token) {
-        output::newline();
-        output::header(snippet.title);
-        output::write(snippet.body.as_str());
-        output::newline();
+        out.push('\n');
+        out.push_str(&header_line(snippet.title));
+        out.push_str(snippet.body.as_str());
+        if !snippet.body.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
     }
+
+    out
 }
 
 const PYICEBERG_TMPL: &str = include_str!("templates/pyiceberg.py.tmpl");

--- a/crates/tower-cmd/src/catalogs.rs
+++ b/crates/tower-cmd/src/catalogs.rs
@@ -1,8 +1,11 @@
-use clap::{value_parser, Arg, ArgMatches, Command};
+use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
 use colored::Colorize;
 use config::Config;
+use tower_api::models::{vend_catalog_credentials_body, CatalogCredentials};
 
 use crate::{api, output, util::cmd};
+
+const STORAGE_CATALOG_TYPE: &str = "tower-catalog";
 
 pub fn catalogs_cmd() -> Command {
     Command::new("catalogs")
@@ -17,14 +20,28 @@ pub fn catalogs_cmd() -> Command {
                         .default_value("default")
                         .value_parser(value_parser!(String))
                         .help("List catalogs in this environment")
-                        .action(clap::ArgAction::Set),
+                        .action(ArgAction::Set),
                 )
                 .arg(
                     Arg::new("all")
                         .short('a')
                         .long("all")
                         .help("List catalogs across all environments")
-                        .action(clap::ArgAction::SetTrue),
+                        .action(ArgAction::SetTrue),
+                )
+                .arg(
+                    Arg::new("type")
+                        .long("type")
+                        .value_parser(value_parser!(String))
+                        .help("Filter catalogs by type, e.g. tower-catalog")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("storage")
+                        .long("storage")
+                        .help("List Tower-managed storage catalogs")
+                        .conflicts_with("type")
+                        .action(ArgAction::SetTrue),
                 )
                 .about("List all of your catalogs"),
         )
@@ -44,18 +61,68 @@ pub fn catalogs_cmd() -> Command {
                         .default_value("default")
                         .value_parser(value_parser!(String))
                         .help("Environment the catalog belongs to")
-                        .action(clap::ArgAction::Set),
+                        .action(ArgAction::Set),
                 )
                 .about("Show the details of a catalog, including its property names"),
+        )
+        .subcommand(
+            Command::new("credentials")
+                .arg(
+                    Arg::new("catalog_name")
+                        .value_parser(value_parser!(String))
+                        .index(1)
+                        .required(true)
+                        .help("Name of the catalog"),
+                )
+                .arg(
+                    Arg::new("environment")
+                        .short('e')
+                        .long("environment")
+                        .default_value("default")
+                        .value_parser(value_parser!(String))
+                        .help("Environment the catalog belongs to")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("mode")
+                        .long("mode")
+                        .default_value("read")
+                        .value_parser(["read", "read-write"])
+                        .help("Credential access mode")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("format")
+                        .long("format")
+                        .default_value("all")
+                        .value_parser(["all", "pyiceberg", "spark", "duckdb", "dbt"])
+                        .help("Snippet format to print")
+                        .action(ArgAction::Set),
+                )
+                .arg(
+                    Arg::new("show_token")
+                        .long("show-token")
+                        .help("Print the vended OAuth token in normal output")
+                        .action(ArgAction::SetTrue),
+                )
+                .about("Vend short-lived catalog credentials for external tools"),
         )
 }
 
 pub async fn do_list(config: Config, args: &ArgMatches) {
     let all = cmd::get_bool_flag(args, "all");
     let env = cmd::get_string_flag(args, "environment");
+    let catalog_type = if cmd::get_bool_flag(args, "storage") {
+        Some(STORAGE_CATALOG_TYPE)
+    } else {
+        args.get_one::<String>("type").map(String::as_str)
+    };
 
-    let catalogs =
-        output::with_spinner("Listing catalogs", api::list_catalogs(&config, &env, all)).await;
+    let catalogs = output::with_spinner(
+        "Listing catalogs",
+        api::list_catalogs(&config, &env, all, catalog_type),
+    )
+    .await;
 
     let headers = vec!["Name", "Type", "Environment"]
         .into_iter()
@@ -74,6 +141,40 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
     output::table(headers, data, Some(&catalogs));
 }
 
+pub async fn do_credentials(config: Config, args: &ArgMatches) {
+    let name = args
+        .get_one::<String>("catalog_name")
+        .expect("catalog_name is required");
+    let env = cmd::get_string_flag(args, "environment");
+    let mode = args
+        .get_one::<String>("mode")
+        .map(String::as_str)
+        .unwrap_or("read");
+    let format = args
+        .get_one::<String>("format")
+        .map(String::as_str)
+        .unwrap_or("all");
+    let show_token = cmd::get_bool_flag(args, "show_token");
+
+    let response = output::with_spinner(
+        "Vending catalog credentials",
+        api::vend_catalog_credentials(&config, name, &env, parse_mode(mode)),
+    )
+    .await;
+
+    output::render_human_or_json(&response, || {
+        print_credentials(
+            name,
+            &env,
+            mode,
+            config.tower_url.as_str(),
+            &response.credentials,
+            format,
+            show_token,
+        );
+    });
+}
+
 pub async fn do_show(config: Config, args: &ArgMatches) {
     let name = args
         .get_one::<String>("catalog_name")
@@ -82,46 +183,220 @@ pub async fn do_show(config: Config, args: &ArgMatches) {
 
     match api::describe_catalog(&config, name, &env).await {
         Ok(response) => {
-            if output::get_output_mode().is_json() {
-                output::json(&response);
-                return;
-            }
+            output::render_human_or_json(&response, || {
+                let catalog = &response.catalog;
 
-            let catalog = &response.catalog;
+                output::detail("Catalog", &catalog.name);
+                output::detail("Type", &catalog.r#type);
+                output::detail("Environment", &catalog.environment);
 
-            output::detail("Catalog", &catalog.name);
-            output::detail("Type", &catalog.r#type);
-            output::detail("Environment", &catalog.environment);
+                if !catalog.properties.is_empty() {
+                    output::newline();
+                    output::header("Properties");
 
-            if !catalog.properties.is_empty() {
-                output::newline();
-                output::header("Properties");
-
-                let headers = vec!["Name", "Runtime Var", "Preview"]
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect();
-                let data = catalog
-                    .properties
-                    .iter()
-                    .map(|prop| {
-                        vec![
-                            prop.name.clone(),
-                            prop.environment_variable.clone().unwrap_or_default(),
-                            prop.preview.dimmed().to_string(),
-                        ]
-                    })
-                    .collect();
-                output::table(headers, data, Some(&response));
-            }
+                    let headers = vec!["Name", "Runtime Var", "Preview"]
+                        .into_iter()
+                        .map(str::to_string)
+                        .collect();
+                    let data = catalog
+                        .properties
+                        .iter()
+                        .map(|prop| {
+                            vec![
+                                prop.name.clone(),
+                                prop.environment_variable.clone().unwrap_or_default(),
+                                prop.preview.dimmed().to_string(),
+                            ]
+                        })
+                        .collect();
+                    output::table(headers, data, Some(&response));
+                }
+            });
         }
         Err(err) => output::tower_error_and_die(err, "Fetching catalog details failed"),
     }
 }
 
+fn parse_mode(mode: &str) -> vend_catalog_credentials_body::Mode {
+    match mode {
+        "read-write" => vend_catalog_credentials_body::Mode::ReadWrite,
+        _ => vend_catalog_credentials_body::Mode::Read,
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn quote(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a string should not fail")
+}
+
+fn sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn sql_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn token_export_command(name: &str, environment: &str, mode: &str, tower_url: &str) -> String {
+    format!(
+        "export TOWER_CATALOG_TOKEN=\"$(tower --tower-url {tower_url} --json catalogs credentials {name} --environment {environment} --mode {mode} | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"credentials\"][\"oauth_token\"])')\"\n",
+        tower_url = shell_quote(tower_url),
+        name = shell_quote(name),
+        environment = shell_quote(environment),
+        mode = shell_quote(mode),
+    )
+}
+
+fn print_credentials(
+    name: &str,
+    environment: &str,
+    mode: &str,
+    tower_url: &str,
+    credentials: &CatalogCredentials,
+    format: &str,
+    show_token: bool,
+) {
+    output::detail("Catalog", name);
+    output::detail("Mode", &credentials.mode);
+    output::detail("Expires", &credentials.expires_at);
+    if show_token {
+        output::detail("Token", &credentials.oauth_token);
+    } else {
+        output::detail("Token", "not printed; snippets read $TOWER_CATALOG_TOKEN");
+    }
+    output::write(&output::paragraph(
+        "These credentials are short-lived and intended for ad-hoc development use.",
+    ));
+    output::newline();
+
+    if !show_token {
+        output::newline();
+        output::header("Shell setup");
+        output::write(token_export_command(name, environment, mode, tower_url).as_str());
+    }
+
+    for snippet in snippets(name, credentials, format, show_token) {
+        output::newline();
+        output::header(snippet.title);
+        output::write(snippet.body.as_str());
+        output::newline();
+    }
+}
+
+const PYICEBERG_TMPL: &str = include_str!("templates/pyiceberg.py.tmpl");
+const SPARK_TMPL: &str = include_str!("templates/spark.py.tmpl");
+const DUCKDB_TMPL: &str = include_str!("templates/duckdb.sql.tmpl");
+const DBT_TMPL: &str = include_str!("templates/dbt.yml.tmpl");
+
+/// Substitute `__TOWER_*__` markers in a connection-snippet template. Values must
+/// already be escaped for the target format — the templates under `src/templates/`
+/// are inert text and the per-format escaping stays in `snippets`.
+fn render(template: &str, vars: &[(&str, String)]) -> String {
+    let mut out = template.to_string();
+    for (marker, value) in vars {
+        out = out.replace(marker, value);
+    }
+    out
+}
+
+struct Snippet {
+    title: &'static str,
+    body: String,
+}
+
+fn snippets(
+    name: &str,
+    credentials: &CatalogCredentials,
+    format: &str,
+    show_token: bool,
+) -> Vec<Snippet> {
+    let all = format == "all";
+    let mut snippets = Vec::new();
+
+    let py_token = if show_token {
+        quote(&credentials.oauth_token)
+    } else {
+        "os.environ[\"TOWER_CATALOG_TOKEN\"]".to_string()
+    };
+    let sql_token = if show_token {
+        sql_string(&credentials.oauth_token)
+    } else {
+        "'${TOWER_CATALOG_TOKEN}'".to_string()
+    };
+    let dbt_token = if show_token {
+        quote(&credentials.oauth_token)
+    } else {
+        "\"{{ env_var('TOWER_CATALOG_TOKEN') }}\"".to_string()
+    };
+    if all || format == "pyiceberg" {
+        snippets.push(Snippet {
+            title: "PyIceberg",
+            body: render(
+                PYICEBERG_TMPL,
+                &[
+                    ("__TOWER_NAME__", quote(name)),
+                    ("__TOWER_URI__", quote(&credentials.catalog_uri)),
+                    ("__TOWER_WAREHOUSE__", quote(&credentials.warehouse)),
+                    ("__TOWER_TOKEN__", py_token.clone()),
+                ],
+            ),
+        });
+    }
+
+    if all || format == "spark" {
+        snippets.push(Snippet {
+            title: "Spark",
+            body: render(
+                SPARK_TMPL,
+                &[
+                    ("__TOWER_NAME__", name.to_string()),
+                    ("__TOWER_URI__", quote(&credentials.catalog_uri)),
+                    ("__TOWER_WAREHOUSE__", quote(&credentials.warehouse)),
+                    ("__TOWER_TOKEN__", py_token.clone()),
+                ],
+            ),
+        });
+    }
+
+    if all || format == "duckdb" {
+        snippets.push(Snippet {
+            title: "DuckDB",
+            body: render(
+                DUCKDB_TMPL,
+                &[
+                    ("__TOWER_NAME__", sql_ident(name)),
+                    ("__TOWER_URI__", sql_string(&credentials.catalog_uri)),
+                    ("__TOWER_WAREHOUSE__", sql_string(&credentials.warehouse)),
+                    ("__TOWER_TOKEN__", sql_token.clone()),
+                ],
+            ),
+        });
+    }
+
+    if all || format == "dbt" {
+        snippets.push(Snippet {
+            title: "dbt",
+            body: render(
+                DBT_TMPL,
+                &[
+                    ("__TOWER_URI__", quote(&credentials.catalog_uri)),
+                    ("__TOWER_WAREHOUSE__", quote(&credentials.warehouse)),
+                    ("__TOWER_TOKEN__", dbt_token.clone()),
+                ],
+            ),
+        });
+    }
+
+    snippets
+}
+
 #[cfg(test)]
 mod tests {
-    use super::catalogs_cmd;
+    use super::{catalogs_cmd, parse_mode, snippets, token_export_command};
+    use tower_api::models::{vend_catalog_credentials_body, CatalogCredentials};
 
     #[test]
     fn list_defaults_to_default_environment() {
@@ -164,6 +439,38 @@ mod tests {
     }
 
     #[test]
+    fn list_accepts_type_filter() {
+        let matches = catalogs_cmd()
+            .try_get_matches_from(["catalogs", "list", "--type", "tower-catalog"])
+            .expect("list --type should parse");
+
+        let (_, list_args) = matches.subcommand().expect("expected list subcommand");
+
+        assert_eq!(
+            list_args.get_one::<String>("type").unwrap(),
+            "tower-catalog"
+        );
+    }
+
+    #[test]
+    fn list_accepts_storage_alias() {
+        let matches = catalogs_cmd()
+            .try_get_matches_from(["catalogs", "list", "--storage"])
+            .expect("list --storage should parse");
+
+        let (_, list_args) = matches.subcommand().expect("expected list subcommand");
+
+        assert_eq!(list_args.get_one::<bool>("storage").copied(), Some(true));
+    }
+
+    #[test]
+    fn list_rejects_type_and_storage_together() {
+        let result =
+            catalogs_cmd().try_get_matches_from(["catalogs", "list", "--storage", "--type", "s3"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn show_requires_catalog_name() {
         let result = catalogs_cmd().try_get_matches_from(["catalogs", "show"]);
         assert!(result.is_err());
@@ -203,5 +510,133 @@ mod tests {
             show_args.get_one::<String>("environment").unwrap(),
             "production"
         );
+    }
+
+    #[test]
+    fn credentials_accepts_catalog_name() {
+        let matches = catalogs_cmd()
+            .try_get_matches_from(["catalogs", "credentials", "default"])
+            .expect("credentials with name should parse");
+
+        let (_, credentials_args) = matches
+            .subcommand()
+            .expect("expected credentials subcommand");
+
+        assert_eq!(
+            credentials_args.get_one::<String>("catalog_name").unwrap(),
+            "default"
+        );
+        assert_eq!(credentials_args.get_one::<String>("mode").unwrap(), "read");
+        assert_eq!(credentials_args.get_one::<String>("format").unwrap(), "all");
+    }
+
+    #[test]
+    fn credentials_accepts_read_write_mode() {
+        let matches = catalogs_cmd()
+            .try_get_matches_from(["catalogs", "credentials", "default", "--mode", "read-write"])
+            .expect("credentials --mode read-write should parse");
+
+        let (_, credentials_args) = matches
+            .subcommand()
+            .expect("expected credentials subcommand");
+
+        assert_eq!(
+            credentials_args.get_one::<String>("mode").unwrap(),
+            "read-write"
+        );
+        assert_eq!(
+            parse_mode(credentials_args.get_one::<String>("mode").unwrap()),
+            vend_catalog_credentials_body::Mode::ReadWrite
+        );
+    }
+
+    #[test]
+    fn token_export_command_fetches_token_without_printing_it() {
+        let credentials = CatalogCredentials::new(
+            "https://catalog.example.com".to_string(),
+            "2026-06-26T12:00:00Z".to_string(),
+            "read".to_string(),
+            "secret-token".to_string(),
+            "warehouse-id".to_string(),
+        );
+
+        let command =
+            token_export_command("default", "production", "read", "http://localhost:8000/");
+
+        assert!(command.contains("export TOWER_CATALOG_TOKEN="));
+        assert!(command.contains("tower --tower-url 'http://localhost:8000/' --json"));
+        assert!(command.contains("catalogs credentials 'default'"));
+        assert!(command.contains("--environment 'production'"));
+        assert!(!command.contains(&credentials.oauth_token));
+    }
+
+    #[test]
+    fn pyiceberg_snippet_reads_token_from_environment_by_default() {
+        let credentials = CatalogCredentials::new(
+            "https://catalog.example.com".to_string(),
+            "2026-06-26T12:00:00Z".to_string(),
+            "read".to_string(),
+            "secret-token".to_string(),
+            "warehouse-id".to_string(),
+        );
+
+        let snippets = snippets("default", &credentials, "pyiceberg", false);
+
+        assert_eq!(snippets.len(), 1);
+        assert!(snippets[0].body.contains("load_catalog"));
+        assert!(snippets[0]
+            .body
+            .contains("os.environ[\"TOWER_CATALOG_TOKEN\"]"));
+        assert!(!snippets[0].body.contains("secret-token"));
+    }
+
+    #[test]
+    fn duckdb_snippet_attaches_catalog_with_secret() {
+        let credentials = CatalogCredentials::new(
+            "https://catalog.example.com".to_string(),
+            "2026-06-26T12:00:00Z".to_string(),
+            "read".to_string(),
+            "secret-token".to_string(),
+            "warehouse-id".to_string(),
+        );
+
+        let snippets = snippets("default", &credentials, "duckdb", false);
+
+        assert_eq!(snippets.len(), 1);
+        assert!(snippets[0]
+            .body
+            .contains("CREATE OR REPLACE SECRET tower_cat (TYPE iceberg"));
+        assert!(snippets[0]
+            .body
+            .contains("ATTACH 'warehouse-id' AS \"default\""));
+        assert!(snippets[0]
+            .body
+            .contains("ENDPOINT 'https://catalog.example.com'"));
+        assert!(snippets[0].body.contains("TOKEN '${TOWER_CATALOG_TOKEN}'"));
+        assert!(!snippets[0].body.contains("secret-token"));
+    }
+
+    #[test]
+    fn all_snippet_templates_fully_render() {
+        let credentials = CatalogCredentials::new(
+            "https://catalog.example.com".to_string(),
+            "2026-06-26T12:00:00Z".to_string(),
+            "read".to_string(),
+            "secret-token".to_string(),
+            "warehouse-id".to_string(),
+        );
+
+        for show_token in [false, true] {
+            let rendered = snippets("default", &credentials, "all", show_token);
+            assert_eq!(rendered.len(), 4);
+            for snippet in &rendered {
+                assert!(
+                    !snippet.body.contains("__TOWER_"),
+                    "unsubstituted marker in {} snippet (show_token={})",
+                    snippet.title,
+                    show_token
+                );
+            }
+        }
     }
 }

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -143,6 +143,9 @@ impl App {
                 match catalogs_command {
                     Some(("list", args)) => catalogs::do_list(sessionized_config, args).await,
                     Some(("show", args)) => catalogs::do_show(sessionized_config, args).await,
+                    Some(("credentials", args)) => {
+                        catalogs::do_credentials(sessionized_config, args).await
+                    }
                     _ => {
                         catalogs::catalogs_cmd().print_help().unwrap();
                         std::process::exit(2);

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -707,7 +707,7 @@ impl TowerService {
         Parameters(request): Parameters<ListCatalogsRequest>,
     ) -> Result<CallToolResult, McpError> {
         let environment = request.environment.as_deref().unwrap_or("default");
-        match api::list_catalogs(&self.config, environment, false).await {
+        match api::list_catalogs(&self.config, environment, false, None).await {
             Ok(catalogs) => {
                 let catalogs: Vec<Value> = catalogs
                     .into_iter()

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -110,6 +110,14 @@ pub fn success(msg: &str) {
     success_with_data(msg, None::<serde_json::Value>);
 }
 
+pub fn render_human_or_json<T: Serialize>(json_data: &T, render_human: impl FnOnce()) {
+    if get_output_mode().is_json() {
+        json(json_data);
+    } else {
+        render_human();
+    }
+}
+
 pub fn success_with_data<T: Serialize>(msg: &str, data: Option<T>) {
     if get_output_mode().is_json() {
         let mut response = serde_json::json!({

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -1,7 +1,7 @@
 pub use cli_table::{format::Justify, Cell};
 use cli_table::{
     format::{Border, HorizontalLine, Separator},
-    print_stdout, Table,
+    print_stdout, Table, TableStruct,
 };
 use colored::{control, Colorize};
 use http::StatusCode;
@@ -110,30 +110,18 @@ pub fn success(msg: &str) {
     success_with_data(msg, None::<serde_json::Value>);
 }
 
-pub fn render_human_or_json<T: Serialize>(json_data: &T, render_human: impl FnOnce()) {
-    if get_output_mode().is_json() {
-        json(json_data);
-    } else {
-        render_human();
-    }
-}
-
 pub fn success_with_data<T: Serialize>(msg: &str, data: Option<T>) {
-    if get_output_mode().is_json() {
-        let mut response = serde_json::json!({
-            "result": "success",
-            "message": msg
-        });
+    let mut response = serde_json::json!({
+        "result": "success",
+        "message": msg
+    });
 
-        if let Some(data) = data {
-            response["data"] = serde_json::to_value(data).unwrap();
-        }
-
-        json(&response);
-    } else {
-        let line = format!("{} {}\n", "Success!".green(), msg);
-        write(&line);
+    if let Some(data) = data {
+        response["data"] = serde_json::to_value(data).unwrap();
     }
+
+    let line = format!("{} {}\n", "Success!".green(), msg);
+    text(&line, &response);
 }
 
 pub enum LogLineType {
@@ -440,6 +428,24 @@ where
     }
 }
 
+fn formatted_table(headers: Vec<String>, data: Vec<Vec<String>>) -> TableStruct {
+    let separator = Separator::builder()
+        .title(Some(HorizontalLine::default()))
+        .build();
+
+    data.table()
+        .border(Border::builder().build())
+        .separator(separator)
+        .title(headers.iter().map(|h| h.bold().yellow().to_string()))
+}
+
+pub fn table_text(headers: Vec<String>, data: Vec<Vec<String>>) -> String {
+    match formatted_table(headers, data).display() {
+        Ok(table) => format!("{}", table),
+        Err(err) => panic!("failed rendering table: {err}"),
+    }
+}
+
 pub fn table<T: Serialize>(headers: Vec<String>, data: Vec<Vec<String>>, json_data: Option<&T>) {
     if get_output_mode().is_json() {
         if let Some(data) = json_data {
@@ -462,15 +468,7 @@ pub fn table<T: Serialize>(headers: Vec<String>, data: Vec<Vec<String>>, json_da
             json(&json_output);
         }
     } else {
-        let separator = Separator::builder()
-            .title(Some(HorizontalLine::default()))
-            .build();
-
-        let table = data
-            .table()
-            .border(Border::builder().build())
-            .separator(separator)
-            .title(headers.iter().map(|h| h.bold().yellow().to_string()));
+        let table = formatted_table(headers, data);
 
         if let Err(err) = print_stdout(table) {
             if err.kind() == io::ErrorKind::BrokenPipe {

--- a/crates/tower-cmd/src/templates/dbt.yml.tmpl
+++ b/crates/tower-cmd/src/templates/dbt.yml.tmpl
@@ -1,0 +1,5 @@
+type: iceberg
+catalog_type: rest
+uri: __TOWER_URI__
+warehouse: __TOWER_WAREHOUSE__
+token: __TOWER_TOKEN__

--- a/crates/tower-cmd/src/templates/duckdb.sql.tmpl
+++ b/crates/tower-cmd/src/templates/duckdb.sql.tmpl
@@ -1,0 +1,9 @@
+duckdb <<SQL
+INSTALL httpfs;
+LOAD httpfs;
+INSTALL iceberg;
+LOAD iceberg;
+SET s3_region='eu-central-1';
+CREATE OR REPLACE SECRET tower_cat (TYPE iceberg, TOKEN __TOWER_TOKEN__);
+ATTACH __TOWER_WAREHOUSE__ AS __TOWER_NAME__ (TYPE iceberg, SECRET tower_cat, ENDPOINT __TOWER_URI__, DEFAULT_REGION 'eu-central-1');
+SQL

--- a/crates/tower-cmd/src/templates/pyiceberg.py.tmpl
+++ b/crates/tower-cmd/src/templates/pyiceberg.py.tmpl
@@ -1,0 +1,10 @@
+import os
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog(
+    __TOWER_NAME__,
+    type="rest",
+    uri=__TOWER_URI__,
+    warehouse=__TOWER_WAREHOUSE__,
+    token=__TOWER_TOKEN__,
+)

--- a/crates/tower-cmd/src/templates/spark.py.tmpl
+++ b/crates/tower-cmd/src/templates/spark.py.tmpl
@@ -1,0 +1,12 @@
+import os
+from pyspark.sql import SparkSession
+
+spark = (
+    SparkSession.builder
+    .config("spark.sql.catalog.__TOWER_NAME__", "org.apache.iceberg.spark.SparkCatalog")
+    .config("spark.sql.catalog.__TOWER_NAME__.type", "rest")
+    .config("spark.sql.catalog.__TOWER_NAME__.uri", __TOWER_URI__)
+    .config("spark.sql.catalog.__TOWER_NAME__.warehouse", __TOWER_WAREHOUSE__)
+    .config("spark.sql.catalog.__TOWER_NAME__.token", __TOWER_TOKEN__)
+    .getOrCreate()
+)

--- a/src/tower/_context.py
+++ b/src/tower/_context.py
@@ -1,4 +1,9 @@
 import os
+from typing import Optional
+
+
+def _getenv_or_none(name: str) -> Optional[str]:
+    return os.getenv(name) or None
 
 
 class TowerContext:
@@ -32,11 +37,15 @@ class TowerContext:
 
     @classmethod
     def build(cls):
-        tower_url = os.getenv("TOWER_URL", "https://api.tower.dev")
-        tower_environment = os.getenv("TOWER_ENVIRONMENT", "default")
-        tower_api_key = os.getenv("TOWER_API_KEY")
-        tower_jwt = os.getenv("TOWER_JWT")
-        tower_run_id = os.getenv("TOWER__RUNTIME__RUN_ID")
+        tower_url = _getenv_or_none("TOWER_URL") or "https://api.tower.dev"
+        tower_environment = (
+            os.getenv("TOWER__RUNTIME__ENVIRONMENT_NAME")
+            or os.getenv("TOWER_ENVIRONMENT")
+            or "default"
+        )
+        tower_api_key = _getenv_or_none("TOWER_API_KEY")
+        tower_jwt = _getenv_or_none("TOWER_JWT")
+        tower_run_id = _getenv_or_none("TOWER__RUNTIME__RUN_ID")
 
         # Replaces the deprecated hugging_face_provider and hugging_face_api_key
         inference_router = os.getenv("TOWER_INFERENCE_ROUTER")

--- a/src/tower/_storage.py
+++ b/src/tower/_storage.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+from typing import Any, Optional
+
+from ._client import _env_client
+from ._context import TowerContext
+from .tower_api_client.api.default import (
+    describe_default_catalog as describe_default_catalog_api,
+)
+from .tower_api_client.api.default import (
+    vend_catalog_credentials as vend_catalog_credentials_api,
+)
+from .tower_api_client.models import (
+    CatalogCredentials,
+    ErrorModel,
+    VendCatalogCredentialsBody,
+    VendCatalogCredentialsBodyMode,
+    VendCatalogCredentialsResponse,
+)
+from .tower_api_client.types import UNSET, Unset
+
+CREDENTIAL_REFRESH_WINDOW = timedelta(minutes=5)
+DEFAULT_CATALOG_PROVISION_RETRY_DELAYS = (0.25, 0.5, 1.0, 2.0)
+DEFAULT_CATALOG_NAME = "default"
+DEFAULT_ENVIRONMENT_NAME = "default"
+
+
+@dataclass
+class _CachedCredentials:
+    credentials: CatalogCredentials
+
+    def is_usable(self, now: datetime) -> bool:
+        expires_at = _ensure_aware(self.credentials.expires_at)
+        return now < expires_at - CREDENTIAL_REFRESH_WINDOW
+
+
+_credential_cache: dict[tuple[str, str, str, str, str], _CachedCredentials] = {}
+
+
+def get_tower_catalog(
+    name: str = DEFAULT_CATALOG_NAME,
+    environment: Optional[str] = None,
+    mode: str = "read",
+) -> Any:
+    """
+    Load a PyIceberg REST catalog using short-lived credentials vended by Tower.
+    """
+    credentials = get_tower_catalog_credentials(name, environment, mode)
+    return load_vended_catalog(name, credentials)
+
+
+def get_tower_catalog_credentials(
+    name: str = DEFAULT_CATALOG_NAME,
+    environment: Optional[str] = None,
+    mode: str = "read",
+) -> CatalogCredentials:
+    ctx = TowerContext.build()
+    environment = environment or ctx.environment or DEFAULT_ENVIRONMENT_NAME
+    mode = _normalize_mode(mode)
+    cache_key = _cache_key(ctx, name, environment, mode)
+
+    now = datetime.now(timezone.utc)
+    _prune_credential_cache(now)
+    cached = _credential_cache.get(cache_key)
+    if cached is not None and cached.is_usable(now):
+        return cached.credentials
+
+    credentials = _vend_with_default_catalog_fallback(ctx, name, environment, mode)
+    _credential_cache[cache_key] = _CachedCredentials(credentials)
+    return credentials
+
+
+def load_vended_catalog(name: str, credentials: CatalogCredentials) -> Any:
+    from pyiceberg.catalog import load_catalog
+
+    return load_catalog(
+        name,
+        type="rest",
+        uri=credentials.catalog_uri,
+        warehouse=credentials.warehouse,
+        token=credentials.oauth_token,
+    )
+
+
+def _vend_with_default_catalog_fallback(
+    ctx: TowerContext, name: str, environment: str, mode: str
+) -> CatalogCredentials:
+    result = _vend_catalog_credentials(ctx, name, environment, mode)
+    if not _is_not_found(result):
+        return _unwrap_vend_result(result, name, environment)
+
+    if name == DEFAULT_CATALOG_NAME and environment == DEFAULT_ENVIRONMENT_NAME:
+        _ensure_legacy_default_catalog(ctx)
+        for delay in DEFAULT_CATALOG_PROVISION_RETRY_DELAYS:
+            time.sleep(delay)
+            result = _vend_catalog_credentials(ctx, name, environment, mode)
+            if not _is_not_found(result):
+                return _unwrap_vend_result(result, name, environment)
+            _ensure_legacy_default_catalog(ctx)
+
+        return _unwrap_vend_result(result, name, environment)
+
+    raise RuntimeError(
+        f"Tower catalog {name!r} does not exist in environment {environment!r}."
+    )
+
+
+def _vend_catalog_credentials(
+    ctx: TowerContext, name: str, environment: str, mode: str
+) -> ErrorModel | VendCatalogCredentialsResponse | None:
+    _ensure_tower_auth(ctx)
+    body = VendCatalogCredentialsBody(mode=_vend_mode(mode))
+    return vend_catalog_credentials_api.sync(
+        name=name,
+        client=_env_client(ctx),
+        environment=environment,
+        body=body,
+    )
+
+
+def _ensure_legacy_default_catalog(ctx: TowerContext) -> None:
+    try:
+        response = describe_default_catalog_api.sync_detailed(client=_env_client(ctx))
+        if response.status_code not in (HTTPStatus.OK, HTTPStatus.ACCEPTED):
+            return
+    except Exception:
+        # The following vend retry will surface the actionable backend/auth error.
+        return
+
+
+def _unwrap_vend_result(
+    result: ErrorModel | VendCatalogCredentialsResponse | None,
+    name: str,
+    environment: str,
+) -> CatalogCredentials:
+    if isinstance(result, VendCatalogCredentialsResponse):
+        return result.credentials
+
+    if isinstance(result, ErrorModel):
+        detail = _error_text(result)
+        raise RuntimeError(
+            f"Failed to vend credentials for Tower catalog {name!r} "
+            f"in environment {environment!r}: {detail}"
+        )
+
+    raise RuntimeError(
+        f"Failed to vend credentials for Tower catalog {name!r} "
+        f"in environment {environment!r}."
+    )
+
+
+def _ensure_tower_auth(ctx: TowerContext) -> None:
+    if ctx.api_key or ctx.jwt:
+        return
+
+    raise RuntimeError("No Tower authentication found. Set TOWER_API_KEY or TOWER_JWT.")
+
+
+def _cache_key(
+    ctx: TowerContext, name: str, environment: str, mode: str
+) -> tuple[str, str, str, str, str]:
+    token = ctx.api_key or ctx.jwt or ""
+    principal_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return (ctx.tower_url, principal_hash, name, environment, mode)
+
+
+def _prune_credential_cache(now: datetime) -> None:
+    expired_keys = [
+        key for key, cached in _credential_cache.items() if not cached.is_usable(now)
+    ]
+    for key in expired_keys:
+        _credential_cache.pop(key, None)
+
+
+def _normalize_mode(mode: str) -> str:
+    if mode not in ("read", "read-write"):
+        raise ValueError("mode must be 'read' or 'read-write'")
+    return mode
+
+
+def _vend_mode(mode: str) -> VendCatalogCredentialsBodyMode:
+    return (
+        VendCatalogCredentialsBodyMode.READ_WRITE
+        if mode == "read-write"
+        else VendCatalogCredentialsBodyMode.READ
+    )
+
+
+def _is_not_found(result: ErrorModel | VendCatalogCredentialsResponse | None) -> bool:
+    return isinstance(result, ErrorModel) and result.status == 404
+
+
+def _error_text(error: ErrorModel) -> str:
+    for value in (error.detail, error.title):
+        if not isinstance(value, Unset) and value:
+            return str(value)
+    return f"HTTP {error.status}" if error.status is not UNSET else "unknown error"
+
+
+def _ensure_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _clear_credential_cache() -> None:
+    _credential_cache.clear()

--- a/src/tower/_tables.py
+++ b/src/tower/_tables.py
@@ -1,33 +1,35 @@
-from typing import Optional, Generic, TypeVar, Union, List
-from dataclasses import dataclass
+from __future__ import annotations
 
-from pyiceberg.exceptions import NoSuchTableError
-from pyiceberg.exceptions import CommitFailedException
+from dataclasses import dataclass
+from typing import List, Optional, TypeVar, Union
+
+from pyiceberg.exceptions import CommitFailedException, NoSuchTableError
 
 TTable = TypeVar("TTable", bound="Table")
+
+import random
+import time
 
 import polars as pl
 import pyarrow as pa
 import pyarrow.compute as pc
-
-from pyiceberg.table import Table as IcebergTable
 from pyiceberg.catalog import (
     Catalog,
     load_catalog,
 )
+from pyiceberg.table import Table as IcebergTable
 
 from ._context import TowerContext
+from ._storage import get_tower_catalog_credentials, load_vended_catalog
+from .tower_api_client.models import CatalogCredentials
 from .utils.pyarrow import (
-    convert_pyarrow_schema,
     convert_pyarrow_expressions,
+    convert_pyarrow_schema,
 )
 from .utils.tables import (
     make_table_name,
     namespace_or_default,
 )
-
-import time
-import random
 
 
 @dataclass
@@ -36,13 +38,42 @@ class RowsAffectedInformation:
     updates: int
 
 
+_VendedCatalogIdentity = tuple[str, str, str]
+
+
+def _vended_catalog_identity(
+    credentials: CatalogCredentials,
+) -> _VendedCatalogIdentity:
+    return (
+        credentials.catalog_uri,
+        credentials.warehouse,
+        credentials.oauth_token,
+    )
+
+
+def _load_tower_catalog(
+    name: str,
+    environment: Optional[str],
+    mode: str,
+) -> tuple[Catalog, _VendedCatalogIdentity]:
+    credentials = get_tower_catalog_credentials(name, environment, mode)
+    return load_vended_catalog(name, credentials), _vended_catalog_identity(credentials)
+
+
 class Table:
     """
     `Table` is a wrapper around an Iceberg table. It provides methods to read and
     write data to the table.
     """
 
-    def __init__(self, context: TowerContext, table: IcebergTable):
+    def __init__(
+        self,
+        context: TowerContext,
+        table: IcebergTable,
+        table_reference: Optional[TableReference] = None,
+        table_identifier: Optional[str] = None,
+        catalog_mode: str = "read",
+    ):
         """
         Initialize a new Table instance that wraps an Iceberg table.
 
@@ -70,6 +101,22 @@ class Table:
         self._stats = RowsAffectedInformation(0, 0)
         self._context = context
         self._table = table
+        self._table_reference = table_reference
+        self._table_identifier = table_identifier
+        self._catalog_mode = catalog_mode
+        self._loaded_from = (
+            table_reference._catalog if table_reference is not None else None
+        )
+
+    def _ensure_read_write_table(self) -> None:
+        if self._table_reference is None or self._table_identifier is None:
+            return
+
+        catalog = self._table_reference._ensure_catalog_mode("read-write")
+        if catalog is not self._loaded_from:
+            self._table = catalog.load_table(self._table_identifier)
+            self._loaded_from = catalog
+        self._catalog_mode = "read-write"
 
     def read(self) -> pl.DataFrame:
         """
@@ -202,6 +249,7 @@ class Table:
             >>> print(f"Inserted {stats.inserts} rows")
         """
         self._validate_retry_args(max_retries, retry_delay_seconds)
+        self._ensure_read_write_table()
 
         last_exception = None
 
@@ -275,6 +323,7 @@ class Table:
             >>> print(f"Inserted {stats.inserts} rows")
         """
         self._validate_retry_args(max_retries, retry_delay_seconds)
+        self._ensure_read_write_table()
 
         last_exception = None
 
@@ -354,6 +403,7 @@ class Table:
             >>> table.delete("age > 30 AND department = 'IT'")
         """
         self._validate_retry_args(max_retries, retry_delay_seconds)
+        self._ensure_read_write_table()
 
         if isinstance(filters, list):
             # We need to convert the pc.Expression into PyIceberg
@@ -441,11 +491,43 @@ class TableReference:
         catalog: Catalog,
         name: str,
         namespace: Optional[str] = None,
+        catalog_name: Optional[str] = None,
+        catalog_environment: Optional[str] = None,
+        tower_vended: bool = False,
+        catalog_mode: str = "read",
+        vended_catalog_identity: Optional[_VendedCatalogIdentity] = None,
     ):
         self._context = ctx
         self._catalog = catalog
         self._name = name
         self._namespace = namespace
+        self._catalog_name = catalog_name
+        self._catalog_environment = catalog_environment
+        self._tower_vended = tower_vended
+        self._catalog_mode = catalog_mode
+        self._vended_catalog_identity = vended_catalog_identity
+
+    def _ensure_catalog_mode(self, mode: str) -> Catalog:
+        if not self._tower_vended or self._catalog_name is None:
+            return self._catalog
+
+        # Keep references read-first; write credentials are vended only on write paths.
+        credentials = get_tower_catalog_credentials(
+            self._catalog_name,
+            environment=self._catalog_environment,
+            mode=mode,
+        )
+        identity = _vended_catalog_identity(credentials)
+
+        if self._catalog_mode != mode or self._vended_catalog_identity != identity:
+            self._catalog = load_vended_catalog(
+                self._catalog_name,
+                credentials,
+            )
+            self._catalog_mode = mode
+            self._vended_catalog_identity = identity
+
+        return self._catalog
 
     def load(self) -> Table:
         """
@@ -471,7 +553,13 @@ class TableReference:
         namespace = namespace_or_default(self._namespace)
         table_name = make_table_name(self._name, namespace)
         table = self._catalog.load_table(table_name)
-        return Table(self._context, table)
+        return Table(
+            self._context,
+            table,
+            table_reference=self if self._tower_vended else None,
+            table_identifier=table_name,
+            catalog_mode=self._catalog_mode,
+        )
 
     def create(self, schema: pa.Schema) -> Table:
         """
@@ -509,20 +597,27 @@ class TableReference:
 
         namespace = namespace_or_default(self._namespace)
         table_name = make_table_name(self._name, namespace)
+        catalog = self._ensure_catalog_mode("read-write")
 
         # We need to create the relevant namespace if it's missing from the
         # resolved namespace.
-        self._catalog.create_namespace_if_not_exists(namespace)
+        catalog.create_namespace_if_not_exists(namespace)
 
         # Now that we're certain the namespace exists, we can create the
         # underlying table. This will return an error if something went wrong
         # along the way.
-        table = self._catalog.create_table(
+        table = catalog.create_table(
             identifier=table_name,
             schema=convert_pyarrow_schema(schema),
         )
 
-        return Table(self._context, table)
+        return Table(
+            self._context,
+            table,
+            table_reference=self if self._tower_vended else None,
+            table_identifier=table_name,
+            catalog_mode=self._catalog_mode,
+        )
 
     def create_if_not_exists(self, schema: pa.Schema) -> Table:
         """
@@ -564,20 +659,27 @@ class TableReference:
 
         namespace = namespace_or_default(self._namespace)
         table_name = make_table_name(self._name, namespace)
+        catalog = self._ensure_catalog_mode("read-write")
 
         # We need to create the relevant namespace if it's missing from the
         # resolved namespace.
-        self._catalog.create_namespace_if_not_exists(namespace)
+        catalog.create_namespace_if_not_exists(namespace)
 
         # We have the catalog, so let's attempt to create the table. It should
         # not return an error and instead just return the table if it already
         # exists.
-        table = self._catalog.create_table_if_not_exists(
+        table = catalog.create_table_if_not_exists(
             identifier=table_name,
             schema=convert_pyarrow_schema(schema),
         )
 
-        return Table(self._context, table)
+        return Table(
+            self._context,
+            table,
+            table_reference=self if self._tower_vended else None,
+            table_identifier=table_name,
+            catalog_mode=self._catalog_mode,
+        )
 
     def drop(self) -> bool:
         """
@@ -605,9 +707,10 @@ class TableReference:
         """
         namespace = namespace_or_default(self._namespace)
         table_name = make_table_name(self._name, namespace)
+        catalog = self._ensure_catalog_mode("read-write")
 
         try:
-            self._catalog.drop_table(table_name)
+            catalog.drop_table(table_name)
             return True
         except NoSuchTableError:
             # If the table doesn't exist or there's any other issue, return False
@@ -617,7 +720,10 @@ class TableReference:
 
 
 def tables(
-    name: str, catalog: Union[str, Catalog] = "default", namespace: Optional[str] = None
+    name: str,
+    catalog: Union[str, Catalog] = "default",
+    namespace: Optional[str] = None,
+    tower_credentials: Optional[bool] = None,
 ) -> TableReference:
     """
     Creates a reference to an Iceberg table that can be used to load or create tables.
@@ -636,6 +742,11 @@ def tables(
             Defaults to "default".
         namespace (Optional[str], optional): The namespace in which the table exists or
             should be created. If not provided, a default namespace will be used.
+        tower_credentials (Optional[bool], optional): Credential resolution for string
+            catalogs. By default (None) and when True, credentials are vended from
+            Tower. Set False to fall back to existing PyIceberg configuration (the
+            legacy ``PYICEBERG_CATALOG__*`` env vars) — a temporary rollback hatch.
+            Ignored when a Catalog instance is passed.
 
     Returns:
         TableReference: A reference object that can be used to:
@@ -671,8 +782,34 @@ def tables(
         >>> if success:
         ...     print("Table dropped successfully")
     """
-    if isinstance(catalog, str):
-        catalog = load_catalog(catalog)
-
     ctx = TowerContext.build()
-    return TableReference(ctx, catalog, name, namespace)
+    tower_vended = False
+    catalog_name = catalog if isinstance(catalog, str) else None
+    vended_catalog_identity = None
+
+    if isinstance(catalog, str):
+        # Tower-managed catalogs always resolve through credential vending.
+        # `tower_credentials=False` is a rollback hatch to the legacy
+        # PYICEBERG_CATALOG__* env-var config (still injected by the runner);
+        # remove it once that injection is gone.
+        if tower_credentials is False:
+            catalog = load_catalog(catalog)
+        else:
+            catalog, vended_catalog_identity = _load_tower_catalog(
+                catalog,
+                environment=ctx.environment,
+                mode="read",
+            )
+            tower_vended = True
+
+    return TableReference(
+        ctx,
+        catalog,
+        name,
+        namespace,
+        catalog_name=catalog_name,
+        catalog_environment=ctx.environment,
+        tower_vended=tower_vended,
+        catalog_mode="read",
+        vended_catalog_identity=vended_catalog_identity,
+    )

--- a/tests/tower/test_storage.py
+++ b/tests/tower/test_storage.py
@@ -1,0 +1,183 @@
+from datetime import datetime, timedelta, timezone
+
+from tower._context import TowerContext
+from tower import _storage
+from tower.tower_api_client.models import (
+    CatalogCredentials,
+    ErrorModel,
+    VendCatalogCredentialsResponse,
+)
+
+
+def clear_tower_env(monkeypatch):
+    for name in (
+        "TOWER_URL",
+        "TOWER_ENVIRONMENT",
+        "TOWER_API_KEY",
+        "TOWER_JWT",
+        "TOWER__RUNTIME__RUN_ID",
+        "TOWER__RUNTIME__ENVIRONMENT_NAME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_context_prefers_runtime_environment(monkeypatch, tmp_path):
+    clear_tower_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("TOWER_ENVIRONMENT", "local-env")
+    monkeypatch.setenv("TOWER__RUNTIME__ENVIRONMENT_NAME", "run-env")
+
+    ctx = TowerContext.build()
+
+    assert ctx.environment == "run-env"
+
+
+def test_context_treats_blank_auth_env_as_missing(monkeypatch, tmp_path):
+    clear_tower_env(monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("TOWER_URL", "")
+    monkeypatch.setenv("TOWER_API_KEY", "")
+    monkeypatch.setenv("TOWER_JWT", "")
+
+    ctx = TowerContext.build()
+
+    assert ctx.tower_url == "https://api.tower.dev"
+    assert ctx.api_key is None
+    assert ctx.jwt is None
+
+
+def test_ensure_tower_auth_requires_explicit_credentials():
+    ctx = TowerContext(tower_url="https://api.example.com", environment="production")
+
+    try:
+        _storage._ensure_tower_auth(ctx)
+    except RuntimeError as error:
+        assert str(error) == (
+            "No Tower authentication found. Set TOWER_API_KEY or TOWER_JWT."
+        )
+    else:
+        raise AssertionError("expected missing-auth error")
+
+    _storage._ensure_tower_auth(
+        TowerContext(
+            tower_url="https://api.example.com",
+            environment="production",
+            api_key="api-key",
+        )
+    )
+    _storage._ensure_tower_auth(
+        TowerContext(
+            tower_url="https://api.example.com",
+            environment="production",
+            jwt="jwt",
+        )
+    )
+
+
+def test_get_tower_catalog_credentials_caches_vended_credentials(monkeypatch):
+    _storage._clear_credential_cache()
+    ctx = TowerContext(
+        tower_url="https://api.example.com",
+        environment="production",
+        api_key="api-key",
+    )
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    credentials = CatalogCredentials(
+        catalog_uri="https://catalog.example.com",
+        expires_at=expires_at,
+        mode="read",
+        oauth_token="oauth-token",
+        warehouse="warehouse-id",
+    )
+    calls = []
+
+    def vend(ctx, name, environment, mode):
+        calls.append((name, environment, mode))
+        return VendCatalogCredentialsResponse(credentials=credentials)
+
+    monkeypatch.setattr(_storage.TowerContext, "build", staticmethod(lambda: ctx))
+    monkeypatch.setattr(_storage, "_vend_catalog_credentials", vend)
+
+    first = _storage.get_tower_catalog_credentials("default")
+    second = _storage.get_tower_catalog_credentials("default")
+
+    assert first is credentials
+    assert second is credentials
+    assert calls == [("default", "production", "read")]
+
+
+def test_get_tower_catalog_credentials_prunes_expired_cache_entries(monkeypatch):
+    _storage._clear_credential_cache()
+    ctx = TowerContext(
+        tower_url="https://api.example.com",
+        environment="production",
+        api_key="api-key",
+    )
+    expired_credentials = CatalogCredentials(
+        catalog_uri="https://old-catalog.example.com",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        mode="read",
+        oauth_token="old-oauth-token",
+        warehouse="old-warehouse-id",
+    )
+    fresh_credentials = CatalogCredentials(
+        catalog_uri="https://catalog.example.com",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        mode="read",
+        oauth_token="oauth-token",
+        warehouse="warehouse-id",
+    )
+    expired_key = _storage._cache_key(ctx, "stale", "production", "read")
+    _storage._credential_cache[expired_key] = _storage._CachedCredentials(
+        expired_credentials
+    )
+
+    def vend(ctx, name, environment, mode):
+        return VendCatalogCredentialsResponse(credentials=fresh_credentials)
+
+    monkeypatch.setattr(_storage.TowerContext, "build", staticmethod(lambda: ctx))
+    monkeypatch.setattr(_storage, "_vend_catalog_credentials", vend)
+
+    result = _storage.get_tower_catalog_credentials("default")
+
+    assert result is fresh_credentials
+    assert expired_key not in _storage._credential_cache
+
+
+def test_default_catalog_vend_retries_after_legacy_provisioning(monkeypatch):
+    _storage._clear_credential_cache()
+    ctx = TowerContext(
+        tower_url="https://api.example.com",
+        environment="default",
+        api_key="api-key",
+    )
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    credentials = CatalogCredentials(
+        catalog_uri="https://catalog.example.com",
+        expires_at=expires_at,
+        mode="read",
+        oauth_token="oauth-token",
+        warehouse="warehouse-id",
+    )
+    responses = [
+        ErrorModel(status=404, detail="not found"),
+        ErrorModel(status=404, detail="still provisioning"),
+        VendCatalogCredentialsResponse(credentials=credentials),
+    ]
+    legacy_calls = []
+
+    def vend(ctx, name, environment, mode):
+        return responses.pop(0)
+
+    def legacy_default(ctx):
+        legacy_calls.append(ctx)
+
+    monkeypatch.setattr(_storage.TowerContext, "build", staticmethod(lambda: ctx))
+    monkeypatch.setattr(_storage, "_vend_catalog_credentials", vend)
+    monkeypatch.setattr(_storage, "_ensure_legacy_default_catalog", legacy_default)
+    monkeypatch.setattr(_storage.time, "sleep", lambda delay: None)
+
+    result = _storage.get_tower_catalog_credentials("default")
+
+    assert result is credentials
+    assert len(legacy_calls) == 2

--- a/tests/tower/test_tables.py
+++ b/tests/tower/test_tables.py
@@ -18,6 +18,59 @@ import concurrent.futures
 
 # Imports the library under test
 import tower
+import tower._tables as tables_module
+from tower._context import TowerContext
+from tower.tower_api_client.models import CatalogCredentials
+
+
+class FakeLoadedTable:
+    def __init__(self, mode: str, identifier: str):
+        self.mode = mode
+        self.identifier = identifier
+        self.append_calls = []
+
+    def append(self, data):
+        self.append_calls.append(data)
+
+
+class FakeCatalog:
+    def __init__(self, mode: str):
+        self.mode = mode
+        self.loaded_identifiers = []
+        self.loaded_tables = []
+
+    def load_table(self, identifier: str):
+        self.loaded_identifiers.append(identifier)
+        table = FakeLoadedTable(self.mode, identifier)
+        self.loaded_tables.append(table)
+        return table
+
+
+def patch_tower_context(
+    monkeypatch,
+    environment: str = "production",
+    api_key: str | None = "api-key",
+    run_id: str | None = None,
+):
+    ctx = TowerContext(
+        tower_url="https://api.example.com",
+        environment=environment,
+        api_key=api_key,
+        run_id=run_id,
+    )
+    monkeypatch.setattr(tables_module.TowerContext, "build", staticmethod(lambda: ctx))
+    return ctx
+
+
+def make_catalog_credentials(mode: str, token: str | None = None):
+    return CatalogCredentials(
+        catalog_uri="https://catalog.example.com",
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+        mode=mode,
+        oauth_token=token or f"{mode}-token",
+        warehouse="warehouse-id",
+    )
 
 
 def get_temp_dir():
@@ -67,6 +120,165 @@ def sql_catalog():
         shutil.rmtree(abs_path)
     except FileNotFoundError:
         pass
+
+
+@pytest.mark.parametrize(
+    ("tower_credentials", "expected_source"),
+    [
+        (None, "vend"),
+        (True, "vend"),
+        (False, "load_catalog"),
+    ],
+)
+def test_string_catalog_precedence(monkeypatch, tower_credentials, expected_source):
+    # Tower-managed catalogs vend by default and when forced; `tower_credentials=False`
+    # is the only path that falls back to existing PyIceberg configuration.
+    patch_tower_context(monkeypatch)
+    vend_catalog = FakeCatalog("vend")
+    configured_catalog = FakeCatalog("configured")
+    calls = []
+
+    def get_tower_catalog_credentials(name, environment=None, mode="read"):
+        calls.append(("vend", name, environment, mode))
+        return make_catalog_credentials(mode)
+
+    def load_vended_catalog(name, credentials):
+        calls.append(("load_vended_catalog", name, credentials.mode))
+        return vend_catalog
+
+    def load_catalog(name):
+        calls.append(("load_catalog", name))
+        return configured_catalog
+
+    monkeypatch.setattr(
+        tables_module, "get_tower_catalog_credentials", get_tower_catalog_credentials
+    )
+    monkeypatch.setattr(tables_module, "load_vended_catalog", load_vended_catalog)
+    monkeypatch.setattr(tables_module, "load_catalog", load_catalog)
+
+    ref = tables_module.tables(
+        "events",
+        catalog="default",
+        tower_credentials=tower_credentials,
+    )
+
+    if expected_source == "vend":
+        assert ref._catalog is vend_catalog
+        assert ref._tower_vended is True
+        assert calls == [
+            ("vend", "default", "production", "read"),
+            ("load_vended_catalog", "default", "read"),
+        ]
+    else:
+        assert ref._catalog is configured_catalog
+        assert ref._tower_vended is False
+        assert calls == [("load_catalog", "default")]
+
+
+def test_vended_table_write_lazily_escalates_and_reuses_catalog(monkeypatch):
+    patch_tower_context(monkeypatch)
+    catalogs = {}
+    credential_calls = []
+
+    def get_tower_catalog_credentials(name, environment=None, mode="read"):
+        credential_calls.append((name, environment, mode))
+        return make_catalog_credentials(mode)
+
+    def load_vended_catalog(name, credentials):
+        catalog = FakeCatalog(credentials.mode)
+        catalogs.setdefault(credentials.mode, []).append(catalog)
+        return catalog
+
+    monkeypatch.setattr(
+        tables_module, "get_tower_catalog_credentials", get_tower_catalog_credentials
+    )
+    monkeypatch.setattr(tables_module, "load_vended_catalog", load_vended_catalog)
+
+    ref = tables_module.tables("events", catalog="default", namespace="demo")
+
+    assert ref._tower_vended is True
+    assert credential_calls == [("default", "production", "read")]
+
+    table = ref.load()
+
+    assert table._catalog_mode == "read"
+    assert catalogs["read"][0].loaded_identifiers == ["demo.events"]
+    assert "read-write" not in catalogs
+
+    data = pa.table({"id": [1, 2, 3]})
+    table.insert(data)
+
+    assert credential_calls == [
+        ("default", "production", "read"),
+        ("default", "production", "read-write"),
+    ]
+    assert catalogs["read"][0].loaded_tables[0].append_calls == []
+    assert catalogs["read-write"][0].loaded_identifiers == ["demo.events"]
+    assert catalogs["read-write"][0].loaded_tables[0].append_calls == [data]
+    assert table._catalog_mode == "read-write"
+    assert table.rows_affected().inserts == 3
+
+    second_batch = pa.table({"id": [4]})
+    table.insert(second_batch)
+
+    assert credential_calls == [
+        ("default", "production", "read"),
+        ("default", "production", "read-write"),
+        ("default", "production", "read-write"),
+    ]
+    assert len(catalogs["read-write"]) == 1
+    assert catalogs["read-write"][0].loaded_identifiers == ["demo.events"]
+    assert catalogs["read-write"][0].loaded_tables[0].append_calls == [
+        data,
+        second_batch,
+    ]
+    assert table.rows_affected().inserts == 4
+
+
+def test_vended_table_write_reloads_when_credentials_change(monkeypatch):
+    patch_tower_context(monkeypatch)
+    catalogs = {}
+    credential_calls = []
+    read_write_credentials = [
+        make_catalog_credentials("read-write", token="write-token-1"),
+        make_catalog_credentials("read-write", token="write-token-2"),
+    ]
+
+    def get_tower_catalog_credentials(name, environment=None, mode="read"):
+        credential_calls.append((name, environment, mode))
+        if mode == "read-write":
+            return read_write_credentials.pop(0)
+        return make_catalog_credentials(mode)
+
+    def load_vended_catalog(name, credentials):
+        catalog = FakeCatalog(credentials.mode)
+        catalogs.setdefault(credentials.mode, []).append(catalog)
+        return catalog
+
+    monkeypatch.setattr(
+        tables_module, "get_tower_catalog_credentials", get_tower_catalog_credentials
+    )
+    monkeypatch.setattr(tables_module, "load_vended_catalog", load_vended_catalog)
+
+    table = tables_module.tables("events", catalog="default", namespace="demo").load()
+
+    first_batch = pa.table({"id": [1]})
+    table.insert(first_batch)
+
+    second_batch = pa.table({"id": [2]})
+    table.insert(second_batch)
+
+    assert credential_calls == [
+        ("default", "production", "read"),
+        ("default", "production", "read-write"),
+        ("default", "production", "read-write"),
+    ]
+    assert len(catalogs["read-write"]) == 2
+    assert catalogs["read-write"][0].loaded_identifiers == ["demo.events"]
+    assert catalogs["read-write"][1].loaded_identifiers == ["demo.events"]
+    assert catalogs["read-write"][0].loaded_tables[0].append_calls == [first_batch]
+    assert catalogs["read-write"][1].loaded_tables[0].append_calls == [second_batch]
+    assert table.rows_affected().inserts == 2
 
 
 def test_reading_and_writing_to_tables(in_memory_catalog):


### PR DESCRIPTION
## Summary

Adds Tower-vended catalog credentials to the CLI and Python SDK so users can access Tower-managed Iceberg catalogs without manually configuring PyIceberg credentials.

This introduces a vend-first path for `tower.tables()`, adds `tower catalogs credentials`, and improves catalog discovery with storage-focused filters.

## Changes

- Added Python SDK support for Tower-vended Iceberg catalog credentials.
- Updated `tower.tables()` so string catalog names use Tower credential vending by default.
- Added lazy write escalation: reads vend `read` credentials first, while writes re-vend `read-write` credentials and reload the table before writing.
- Kept custom PyIceberg `Catalog` objects working for tests and advanced/custom usage.
- Added a temporary `tower_credentials=False` rollback path for legacy PyIceberg config loading.
- Added credential caching with refresh before token expiry.
- Added default-catalog retry handling for first-time provisioning races.
- Updated Tower context handling to prefer runtime environment values and support logged-in session auth from the local Tower config.
- Added `tower catalogs list --type <type>` and `tower catalogs list --storage`.
- Added `tower catalogs credentials <name>` with snippets for:
  - PyIceberg
  - Spark
  - DuckDB
  - dbt
  - DBeaver
- Made normal credential output avoid printing tokens by default, using `TOWER_CATALOG_TOKEN` instead.
- Added `--show-token` for explicit token printing and `--json` for raw machine-readable output.

New commands and command variations:
```
# --- Catalog discovery (new flags on `catalogs list`) ---
tower catalogs list --storage                       # only Tower-managed (tower-catalog) catalogs
tower catalogs list --type tower-catalog            # same, explicit
tower catalogs list --type s3-tables -e production  # filter by any type, scoped to an environment

# --- Vend short-lived credentials + print connection snippets (new subcommand) ---
tower catalogs credentials <name>                          # all snippets, read-only, token redacted
tower catalogs credentials <name> --format pyiceberg       # one tool: pyiceberg | spark | duckdb | dbt | dbeaver | all
tower catalogs credentials <name> --mode read-write        # read-write creds (requires catalog write permission)
tower catalogs credentials <name> -e production            # choose the environment (default: "default")
tower catalogs credentials <name> --show-token             # inline the real token instead of $TOWER_CATALOG_TOKEN
tower --json catalogs credentials <name>                   # raw JSON (includes the token) for scripting
```

New sdk behavior:
```
import tower

# String catalog name → Tower-vended credentials (laptop, CI, or in a run)
df = tower.tables("events").load().read()              # read-only creds
tower.tables("events").insert(data)                    # escalates to read-write on write

tower.tables("events", tower_credentials=False)        # opt out → legacy local PyIceberg config
tower.tables("events", catalog=my_pyiceberg_catalog)   # custom Catalog object, unchanged
```

Some local testing:
List storage catalogs only (catalog type == tower-catalog)
<img width="607" height="90" alt="image" src="https://github.com/user-attachments/assets/10f69d95-5312-4cc9-b180-8a00b33155f5" />

Show a catalog:
<img width="755" height="205" alt="image" src="https://github.com/user-attachments/assets/cd33c81e-e77f-4eed-96b6-bc226c25b4ee" />

Vend credentials for a catalog:
```
cargo run -- catalogs credentials default1 --environment default --mode read
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/tower catalogs credentials default1 --environment default --mode read`
✔ Vending catalog credentials... Done!
Catalog: default1
Mode: read
Expires: 2026-06-29T17:24:04.613338+02:00
Token: not printed; snippets read $TOWER_CATALOG_TOKEN
  These credentials are short-lived and intended for ad-hoc development use.

Shell setup
export TOWER_CATALOG_TOKEN="$(tower --json catalogs credentials 'default1' --environment 'default' --mode 'read' | python3 -c 'import json,sys; print(json.load(sys.stdin)["credentials"]["oauth_token"])')"

PyIceberg
import os
from pyiceberg.catalog import load_catalog

catalog = load_catalog(
    "default1",
    type="rest",
    uri="<tower's_very_secret_polaris_instance>",
    warehouse="<fully_qualified_catalog_name>",
    token=os.environ["TOWER_CATALOG_TOKEN"],
)


Spark
import os
from pyspark.sql import SparkSession

spark = (
    SparkSession.builder
    .config("spark.sql.catalog.default1", "org.apache.iceberg.spark.SparkCatalog")
    .config("spark.sql.catalog.default1.type", "rest")
    .config("spark.sql.catalog.default1.uri", "<tower's_very_secret_polaris_instance>")
    .config("spark.sql.catalog.default1.warehouse", "<fully_qualified_catalog_name>")
    .config("spark.sql.catalog.default1.token", os.environ["TOWER_CATALOG_TOKEN"])
    .getOrCreate()
)


DuckDB
duckdb <<SQL
INSTALL httpfs;
LOAD httpfs;
INSTALL iceberg;
LOAD iceberg;
SET s3_region='eu-central-1';
CREATE OR REPLACE SECRET tower_cat (TYPE iceberg, TOKEN '${TOWER_CATALOG_TOKEN}');
ATTACH '<fully_qualified_catalog_name>' AS "default1" (TYPE iceberg, SECRET tower_cat, ENDPOINT '<tower's_very_secret_polaris_instance>', DEFAULT_REGION 'eu-central-1');
SQL


dbt
type: iceberg
catalog_type: rest
uri: "<tower's_very_secrect_polaris_instance>"
warehouse: "<fully_qualified_catalog_name>"
token: "{{ env_var('TOWER_CATALOG_TOKEN') }}"


DBeaver
Catalog type: Iceberg REST
URI: <tower's_very_secret_polaris_instance>
Warehouse: <fully_qualified_catalog_name>
Authentication: Bearer token
Token: $TOWER_CATALOG_TOKEN
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `catalogs credentials` command to generate short-lived catalog credentials and ready-to-use connection snippets.
  * Added catalog filtering to `catalogs list`, including a new `--type` option and a `--storage` shortcut.
  * Expanded supported snippet formats for tools like DuckDB, dbt, PyIceberg, and Spark.

* **Bug Fixes**
  * Improved catalog and table access so write operations automatically switch to the needed access mode.
  * Enhanced session-based settings lookup for more reliable CLI behavior when environment variables are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->