### PR TITLE
chore: bump version to v0.3.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "base64",
  "chrono",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "crypto"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "testutils"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "pem",
  "rsa",
@@ -3663,7 +3663,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "config",
  "pyo3",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "tower-api"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "reqwest",
  "serde",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "tower-cmd"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "axum",
  "bytes",
@@ -3775,7 +3775,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-package"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "async-compression",
  "flate2",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "tower-runtime"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3824,7 +3824,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower-telemetry"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "tracing",
  "tracing-appender",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "tower-uv"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "async-compression",
  "async_zip",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "tower-version"
-version = "0.3.67"
+version = "0.3.68"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.67"
+version = "0.3.68"
 description = "Tower is the best way to host Python data apps in production"
 rust-version = "1.81"
 authors = ["Brad Heller <brad@tower.dev>", "Ben Lovell <ben@tower.dev>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tower"
-version = "0.3.67"
+version = "0.3.68"
 description = "Tower CLI and runtime environment for Tower."
 authors = [{ name = "Tower Computing Inc.", email = "brad@tower.dev" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -2080,7 +2080,7 @@ wheels = [
 
 [[package]]
 name = "tower"
-version = "0.3.67"
+version = "0.3.68"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Bumps the workspace version 0.3.67 → 0.3.68 ahead of cutting the next release.

Unreleased since v0.3.67: #288, #286, #308, #307, #306.