### PR TITLE
Remove registry-url from publish-npm.yml

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm to latest patch
         run: npm install -g npm@latest
       - name: Publish to npm


### PR DESCRIPTION
It's not necessary, and it might be causing the entire workflow to fail.