### PR TITLE
fix(tower-uv): use copy link mode when no cache dir is set

### DIFF
--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -302,6 +302,20 @@ impl Uv {
         }
     }
 
+    // When no explicit cache dir is configured, uv uses its default cache
+    // (`~/.cache/uv`). In containerized/sandboxed execution that default often
+    // lives on a different filesystem than the target venv, so hardlinks across
+    // the two fail with EXDEV and uv prints a "Failed to hardlink files; falling
+    // back to full copy" warning into the setup logs. Force copy mode there so
+    // the warning is suppressed (uv was already copying anyway). Callers that
+    // pass an explicit cache dir on the same filesystem as the venv keep fast
+    // hardlink/clone.
+    fn apply_link_mode(&self, cmd: &mut Command) {
+        if self.cache_dir.is_none() {
+            cmd.env("UV_LINK_MODE", "copy");
+        }
+    }
+
     pub async fn venv(
         &self,
         cwd: &PathBuf,
@@ -361,6 +375,7 @@ impl Uv {
             if let Some(dir) = &self.cache_dir {
                 cmd.arg("--cache-dir").arg(dir);
             }
+            self.apply_link_mode(&mut cmd);
 
             let child = cmd.spawn()?;
 
@@ -406,6 +421,7 @@ impl Uv {
             .arg("never")
             .arg("pip")
             .arg("install");
+        self.apply_link_mode(&mut cmd);
         cmd
     }
 
@@ -494,6 +510,8 @@ impl Uv {
 
         // Need to do this after env_clear intentionally.
         cmd.envs(env_vars);
+        // Also after env_clear so protected mode doesn't wipe it.
+        self.apply_link_mode(&mut cmd);
 
         if let Some(dir) = &self.cache_dir {
             cmd.arg("--cache-dir").arg(dir);

--- a/crates/tower-uv/src/lib.rs
+++ b/crates/tower-uv/src/lib.rs
@@ -302,14 +302,10 @@ impl Uv {
         }
     }
 
-    // When no explicit cache dir is configured, uv uses its default cache
-    // (`~/.cache/uv`). In containerized/sandboxed execution that default often
-    // lives on a different filesystem than the target venv, so hardlinks across
-    // the two fail with EXDEV and uv prints a "Failed to hardlink files; falling
-    // back to full copy" warning into the setup logs. Force copy mode there so
-    // the warning is suppressed (uv was already copying anyway). Callers that
-    // pass an explicit cache dir on the same filesystem as the venv keep fast
-    // hardlink/clone.
+    // Without an explicit cache dir, uv's default cache may be on a different
+    // filesystem than the target venv, so hardlinking fails and uv warns before
+    // falling back to a copy. Force copy mode to skip the failed attempt and the
+    // warning.
     fn apply_link_mode(&self, cmd: &mut Command) {
         if self.cache_dir.is_none() {
             cmd.env("UV_LINK_MODE", "copy");


### PR DESCRIPTION
When a Python app is set up, `uv` occasionally prints this warning into the setup logs:

```
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set \`export UV_LINK_MODE=copy\` or use \`--link-mode=copy\` to suppress this warning.
```

## Root cause

When `tower_uv::Uv` is constructed without an explicit cache dir, `uv` uses its default cache (`~/.cache/uv`). In sandboxed execution the default cache and the target virtualenv frequently live on different filesystems, so `uv` can't hardlink across them and falls back to copying, emitting the warning. It looks intermittent because it only surfaces on runs whose app actually has dependencies to materialize into the venv.

The copy fallback was already happening; the warning is just noise.