### PR TITLE
refactor(cli): replace the output globals with an explicit `Out`

### DIFF
--- a/crates/tower-cmd/src/apps.rs
+++ b/crates/tower-cmd/src/apps.rs
@@ -1,4 +1,5 @@
 use clap::{value_parser, Arg, ArgMatches, Command};
+use colored::Colorize;
 use config::Config;
 use tokio::sync::oneshot;
 use tokio::time::{sleep, Duration, Instant};
@@ -116,123 +117,118 @@ pub fn apps_cmd() -> Command {
         )
 }
 
-pub async fn do_logs(config: Config, cmd: &ArgMatches) {
+pub async fn do_logs(out: &output::Out, config: Config, cmd: &ArgMatches) {
     let app_name_raw = cmd
         .get_one::<String>("app_name")
         .expect("app_name is required");
     let (name, seq) = if let Some((name, num_str)) = app_name_raw.split_once('#') {
         let num = num_str
             .parse::<i64>()
-            .unwrap_or_else(|_| output::die("Run number must be a number"));
+            .unwrap_or_else(|_| out.die("Run number must be a number"));
         (name.to_string(), num)
     } else {
         let num = match cmd.get_one::<i64>("run_number").copied() {
             Some(n) => n,
-            None => latest_run_number(&config, app_name_raw).await,
+            None => latest_run_number(out, &config, app_name_raw).await,
         };
         (app_name_raw.clone(), num)
     };
     let follow = cmd.get_one::<bool>("follow").copied().unwrap_or(false);
 
     if follow {
-        follow_logs(config, name, seq).await;
+        follow_logs(out, config, name, seq).await;
         return;
     }
 
     if let Ok(resp) = api::describe_run_logs(&config, &name, seq).await {
         for line in resp.log_lines {
-            output::remote_log_event(&line);
+            out.remote_log_event(&line);
         }
     }
 }
 
-pub async fn do_show(config: Config, cmd: &ArgMatches) {
+pub async fn do_show(out: &output::Out, config: Config, cmd: &ArgMatches) {
     let name = cmd
         .get_one::<String>("app_name")
         .expect("app_name is required");
     let env = cmd::get_string_flag(cmd, "environment");
 
     match api::describe_app(&config, &name, Some(&env)).await {
-        Ok(app_response) => {
-            if output::get_output_mode().is_json() {
-                output::json(&app_response);
-                return;
-            }
-
-            let app = &app_response.app;
-            let runs = &app_response.runs;
-
-            output::detail("Name", &app.name);
-            output::header("Description");
-            let line = output::paragraph(&app.short_description);
-            output::write(&line);
-            output::newline();
-            output::newline();
-            output::header("Recent runs");
-
-            let headers = vec!["#", "Status", "Start Time", "Elapsed Time"]
-                .into_iter()
-                .map(str::to_string)
-                .collect();
-
-            let rows = runs
-                .iter()
-                .map(|run: &Run| {
-                    let status = &run.status;
-                    let status_str = format!("{:?}", status);
-
-                    // Format start time
-                    let start_time = if let Some(started_at) = &run.started_at {
-                        if !started_at.is_empty() {
-                            started_at.to_string()
-                        } else {
-                            format!("Scheduled at {}", &run.scheduled_at)
-                        }
-                    } else {
-                        format!("Scheduled at {}", &run.scheduled_at)
-                    };
-
-                    // Calculate elapsed time
-                    let elapsed_time = if let Some(ended_at) = &run.ended_at {
-                        if !ended_at.is_empty() {
-                            if let (Some(started_at), Some(ended_at)) =
-                                (&run.started_at, &run.ended_at)
-                            {
-                                let start =
-                                    started_at.parse::<chrono::DateTime<chrono::Utc>>().ok();
-                                let end = ended_at.parse::<chrono::DateTime<chrono::Utc>>().ok();
-                                if let (Some(start), Some(end)) = (start, end) {
-                                    format!("{:.1}s", (end - start).num_seconds())
-                                } else {
-                                    "Invalid time".into()
-                                }
-                            } else {
-                                "Invalid time".into()
-                            }
-                        } else if run.started_at.is_some() {
-                            "Running".into()
-                        } else {
-                            "Pending".into()
-                        }
-                    } else if run.started_at.is_some() {
-                        "Running".into()
-                    } else {
-                        "Pending".into()
-                    };
-
-                    vec![run.number.to_string(), status_str, start_time, elapsed_time]
-                })
-                .collect();
-
-            output::table(headers, rows, Some(&app_response));
-        }
-        Err(err) => output::tower_error_and_die(err, "Fetching app details failed"),
+        Ok(app_response) => out.text(&app_details_text(&app_response), &app_response),
+        Err(err) => out.tower_error_and_die(err, "Fetching app details failed"),
     }
 }
 
-pub async fn do_list_apps(config: Config, args: &ArgMatches) {
+fn app_details_text(response: &tower_api::models::DescribeAppResponse) -> String {
+    let app = &response.app;
+    let mut text = String::new();
+
+    text.push_str(&format!("{} {}\n", "Name:".bold().green(), app.name));
+    text.push_str(&format!("{}\n", "Description".bold().green()));
+    text.push_str(&output::paragraph(&app.short_description));
+    text.push_str("\n\n");
+    text.push_str(&format!("{}\n", "Recent runs".bold().green()));
+
+    let headers = vec!["#", "Status", "Start Time", "Elapsed Time"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+    let rows = response
+        .runs
+        .iter()
+        .map(|run: &Run| {
+            let status_str = format!("{:?}", &run.status);
+
+            // Format start time
+            let start_time = if let Some(started_at) = &run.started_at {
+                if !started_at.is_empty() {
+                    started_at.to_string()
+                } else {
+                    format!("Scheduled at {}", &run.scheduled_at)
+                }
+            } else {
+                format!("Scheduled at {}", &run.scheduled_at)
+            };
+
+            // Calculate elapsed time
+            let elapsed_time = if let Some(ended_at) = &run.ended_at {
+                if !ended_at.is_empty() {
+                    if let (Some(started_at), Some(ended_at)) = (&run.started_at, &run.ended_at) {
+                        let start = started_at.parse::<chrono::DateTime<chrono::Utc>>().ok();
+                        let end = ended_at.parse::<chrono::DateTime<chrono::Utc>>().ok();
+                        if let (Some(start), Some(end)) = (start, end) {
+                            format!("{:.1}s", (end - start).num_seconds())
+                        } else {
+                            "Invalid time".into()
+                        }
+                    } else {
+                        "Invalid time".into()
+                    }
+                } else if run.started_at.is_some() {
+                    "Running".into()
+                } else {
+                    "Pending".into()
+                }
+            } else if run.started_at.is_some() {
+                "Running".into()
+            } else {
+                "Pending".into()
+            };
+
+            vec![run.number.to_string(), status_str, start_time, elapsed_time]
+        })
+        .collect();
+
+    text.push_str(&format!("{}\n", output::table_text(headers, rows)));
+    text
+}
+
+pub async fn do_list_apps(out: &output::Out, config: Config, args: &ArgMatches) {
     let env = args.get_one::<String>("environment").map(|s| s.as_str());
-    let apps = output::with_spinner("Listing apps", api::list_apps(&config, env)).await;
+    let apps = out
+        .with_spinner("Listing apps", api::list_apps(&config, env))
+        .await;
 
     let items = apps
         .iter()
@@ -246,31 +242,33 @@ pub async fn do_list_apps(config: Config, args: &ArgMatches) {
             format!("{}\n{}", output::title(&app.name), desc)
         })
         .collect();
-    output::list(items, Some(&apps));
+    out.list(items, Some(&apps));
 }
 
-pub async fn do_create(config: Config, args: &ArgMatches) {
+pub async fn do_create(out: &output::Out, config: Config, args: &ArgMatches) {
     let name = args.get_one::<String>("name").unwrap_or_else(|| {
-        output::die("App name (--name) is required");
+        out.die("App name (--name) is required");
     });
 
     let description = args.get_one::<String>("description").unwrap();
 
-    let app =
-        output::with_spinner("Creating app", api::create_app(&config, name, description)).await;
+    let app = out
+        .with_spinner("Creating app", api::create_app(&config, name, description))
+        .await;
 
-    output::success_with_data(&format!("App '{}' created", name), Some(app));
+    out.success_with_data(&format!("App '{}' created", name), Some(app));
 }
 
-pub async fn do_delete(config: Config, cmd: &ArgMatches) {
+pub async fn do_delete(out: &output::Out, config: Config, cmd: &ArgMatches) {
     let name = cmd
         .get_one::<String>("app_name")
         .expect("app_name is required");
 
-    output::with_spinner("Deleting app", api::delete_app(&config, name)).await;
+    out.with_spinner("Deleting app", api::delete_app(&config, name))
+        .await;
 }
 
-pub async fn do_cancel(config: Config, cmd: &ArgMatches) {
+pub async fn do_cancel(out: &output::Out, config: Config, cmd: &ArgMatches) {
     let name = cmd
         .get_one::<String>("app_name")
         .expect("app_name should be required");
@@ -279,26 +277,27 @@ pub async fn do_cancel(config: Config, cmd: &ArgMatches) {
         .copied()
         .expect("run_number should be required");
 
-    let response =
-        output::with_spinner("Cancelling run", api::cancel_run(&config, name, seq)).await;
+    let response = out
+        .with_spinner("Cancelling run", api::cancel_run(&config, name, seq))
+        .await;
 
     let run = &response.run;
     let status = format!("{:?}", run.status);
-    output::success_with_data(
+    out.success_with_data(
         &format!("Run #{} for '{}' cancelled (status: {})", seq, name, status),
         Some(response),
     );
 }
 
-async fn latest_run_number(config: &Config, name: &str) -> i64 {
+async fn latest_run_number(out: &output::Out, config: &Config, name: &str) -> i64 {
     match api::describe_app(config, name, None).await {
         Ok(resp) => resp
             .runs
             .iter()
             .map(|r| r.number)
             .max()
-            .unwrap_or_else(|| output::die(&format!("No runs found for app '{}'", name))),
-        Err(err) => output::tower_error_and_die(err, "Fetching app details failed"),
+            .unwrap_or_else(|| out.die(&format!("No runs found for app '{}'", name))),
+        Err(err) => out.tower_error_and_die(err, "Fetching app details failed"),
     }
 }
 
@@ -309,8 +308,7 @@ const RUN_START_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const RUN_START_MESSAGE_DELAY: Duration = Duration::from_secs(3);
 const RUN_START_TIMEOUT: Duration = Duration::from_secs(30);
 
-async fn follow_logs(config: Config, name: String, seq: i64) {
-    let enable_ctrl_c = !output::get_output_mode().is_mcp();
+async fn follow_logs(out: &output::Out, config: Config, name: String, seq: i64) {
     let mut backoff = FOLLOW_BACKOFF_INITIAL;
     let mut cancel_monitor: Option<oneshot::Sender<()>> = None;
     let mut last_line_num: Option<i64> = None;
@@ -318,13 +316,13 @@ async fn follow_logs(config: Config, name: String, seq: i64) {
     loop {
         let mut run = match api::describe_run(&config, &name, seq).await {
             Ok(res) => res.run,
-            Err(err) => output::tower_error_and_die(err, "Fetching run details failed"),
+            Err(err) => out.tower_error_and_die(err, "Fetching run details failed"),
         };
 
         if is_run_finished(&run) {
             if let Ok(resp) = api::describe_run_logs(&config, &name, seq).await {
                 for line in resp.log_lines {
-                    emit_log_if_new(&line, &mut last_line_num);
+                    emit_log_if_new(out, &line, &mut last_line_num);
                 }
             }
             return;
@@ -337,25 +335,23 @@ async fn follow_logs(config: Config, name: String, seq: i64) {
                 sleep(RUN_START_POLL_INTERVAL).await;
 
                 if wait_started.elapsed() > RUN_START_TIMEOUT {
-                    output::error(
-                        "Timed out waiting for run to start. The runner may be unavailable.",
-                    );
+                    out.error("Timed out waiting for run to start. The runner may be unavailable.");
                     return;
                 }
 
                 // Avoid blank output on slow starts while keeping fast starts quiet.
                 if should_notify_run_wait(notified, wait_started.elapsed()) {
-                    output::write("Waiting for run to start...\n");
+                    out.write("Waiting for run to start...\n");
                     notified = true;
                 }
                 run = match api::describe_run(&config, &name, seq).await {
                     Ok(res) => res.run,
-                    Err(err) => output::tower_error_and_die(err, "Fetching run details failed"),
+                    Err(err) => out.tower_error_and_die(err, "Fetching run details failed"),
                 };
                 if is_run_finished(&run) {
                     if let Ok(resp) = api::describe_run_logs(&config, &name, seq).await {
                         for line in resp.log_lines {
-                            emit_log_if_new(&line, &mut last_line_num);
+                            emit_log_if_new(out, &line, &mut last_line_num);
                         }
                     }
                     return;
@@ -378,9 +374,10 @@ async fn follow_logs(config: Config, name: String, seq: i64) {
                 // Reset after a successful connection so transient drops recover quickly.
                 backoff = FOLLOW_BACKOFF_INITIAL;
                 match stream_logs_until_complete(
+                    out,
                     log_stream,
                     run_complete,
-                    enable_ctrl_c,
+                    out.foreground(),
                     &run.dollar_link,
                     &mut last_line_num,
                 )
@@ -409,10 +406,10 @@ async fn follow_logs(config: Config, name: String, seq: i64) {
             }
             Err(err) => {
                 if is_fatal_stream_error(&err) {
-                    output::error(&format!("Failed to stream run logs: {}", err));
+                    out.error(&format!("Failed to stream run logs: {}", err));
                     return;
                 }
-                output::error(&format!("Failed to stream run logs: {}", err));
+                out.error(&format!("Failed to stream run logs: {}", err));
                 sleep(backoff).await;
                 backoff = next_backoff(backoff);
                 continue;
@@ -421,7 +418,7 @@ async fn follow_logs(config: Config, name: String, seq: i64) {
 
         let latest = match api::describe_run(&config, &name, seq).await {
             Ok(res) => res.run,
-            Err(err) => output::tower_error_and_die(err, "Fetching run details failed"),
+            Err(err) => out.tower_error_and_die(err, "Fetching run details failed"),
         };
         if is_run_finished(&latest) {
             return;
@@ -448,6 +445,7 @@ enum LogFollowOutcome {
 }
 
 async fn stream_logs_until_complete(
+    out: &output::Out,
     mut log_stream: tokio::sync::mpsc::Receiver<api::LogStreamEvent>,
     mut run_complete: oneshot::Receiver<Run>,
     enable_ctrl_c: bool,
@@ -458,17 +456,17 @@ async fn stream_logs_until_complete(
         tokio::select! {
             event = log_stream.recv() => match event {
                 Some(api::LogStreamEvent::EventLog(log)) => {
-                    emit_log_if_new(&log, last_line_num);
+                    emit_log_if_new(out, &log, last_line_num);
                 },
                 Some(api::LogStreamEvent::EventWarning(warning)) => {
-                    output::write(&format!("Warning: {}\n", warning.data.content));
+                    out.write(&format!("Warning: {}\n", warning.data.content));
                 }
                 None => return Ok(LogFollowOutcome::Disconnected),
             },
             res = &mut run_complete => {
                 match res {
                     Ok(_) => {
-                        drain_remaining_logs(log_stream, last_line_num).await;
+                        drain_remaining_logs(out, log_stream, last_line_num).await;
                         return Ok(LogFollowOutcome::Completed);
                     }
                     // If monitoring failed, keep following and let the caller retry.
@@ -476,9 +474,9 @@ async fn stream_logs_until_complete(
                 }
             },
             _ = tokio::signal::ctrl_c(), if enable_ctrl_c => {
-                output::write("Received Ctrl+C, stopping log streaming...\n");
-                output::write("Note: The run will continue in Tower cloud\n");
-                output::write(&format!("  See more: {}\n", run_link));
+                out.write("Received Ctrl+C, stopping log streaming...\n");
+                out.write("Note: The run will continue in Tower cloud\n");
+                out.write(&format!("  See more: {}\n", run_link));
                 return Ok(LogFollowOutcome::Interrupted);
             },
         }
@@ -486,6 +484,7 @@ async fn stream_logs_until_complete(
 }
 
 async fn drain_remaining_logs(
+    out: &output::Out,
     mut log_stream: tokio::sync::mpsc::Receiver<api::LogStreamEvent>,
     last_line_num: &mut Option<i64>,
 ) {
@@ -493,10 +492,10 @@ async fn drain_remaining_logs(
         while let Some(event) = log_stream.recv().await {
             match event {
                 api::LogStreamEvent::EventLog(log) => {
-                    emit_log_if_new(&log, last_line_num);
+                    emit_log_if_new(out, &log, last_line_num);
                 }
                 api::LogStreamEvent::EventWarning(warning) => {
-                    output::write(&format!("Warning: {}\n", warning.data.content));
+                    out.write(&format!("Warning: {}\n", warning.data.content));
                 }
             }
         }
@@ -504,9 +503,9 @@ async fn drain_remaining_logs(
     .await;
 }
 
-fn emit_log_if_new(log: &RunLogLine, last_line_num: &mut Option<i64>) {
+fn emit_log_if_new(out: &output::Out, log: &RunLogLine, last_line_num: &mut Option<i64>) {
     if should_emit_line(last_line_num, log.line_num) {
-        output::remote_log_event(log);
+        out.remote_log_event(log);
     }
 }
 
@@ -555,7 +554,7 @@ fn monitor_run_completion(
                     Err(_) => {
                         failures += 1;
                         if failures >= 5 {
-                            output::error(
+                            output::background_error(
                                 "Failed to monitor run completion after repeated errors",
                             );
                             return;
@@ -744,7 +743,9 @@ mod tests {
             drop(tx);
         });
 
-        let res = stream_logs_until_complete(rx, done_rx, false, "link", &mut last_line_num).await;
+        let out = crate::output::Out::sink();
+        let res =
+            stream_logs_until_complete(&out, rx, done_rx, false, "link", &mut last_line_num).await;
         done_task.await.unwrap();
 
         assert!(matches!(res, Ok(LogFollowOutcome::Completed)));
@@ -757,7 +758,9 @@ mod tests {
         let (_done_tx, done_rx) = oneshot::channel::<Run>();
         let mut last_line_num = None;
 
-        let res = stream_logs_until_complete(rx, done_rx, false, "link", &mut last_line_num).await;
+        let out = crate::output::Out::sink();
+        let res =
+            stream_logs_until_complete(&out, rx, done_rx, false, "link", &mut last_line_num).await;
 
         assert!(matches!(res, Ok(LogFollowOutcome::Disconnected)));
     }

--- a/crates/tower-cmd/src/beta.rs
+++ b/crates/tower-cmd/src/beta.rs
@@ -2,7 +2,7 @@ use std::io::{self, IsTerminal};
 
 use tower_telemetry::debug;
 
-use crate::output::{self, OutputMode};
+use crate::output::{self, Out};
 
 pub(crate) struct BetaFeature {
     id: &'static str,
@@ -31,12 +31,10 @@ pub(crate) const STORAGE: BetaFeature = BetaFeature {
     docs_url: None,
 };
 
-pub(crate) fn notify_once(feature: &BetaFeature) {
-    let output_mode = output::get_output_mode();
-    let stdout_is_terminal = io::stdout().is_terminal();
+pub(crate) fn notify_once(out: &Out, feature: &BetaFeature) {
     let stderr_is_terminal = io::stderr().is_terminal();
 
-    if !should_notify(output_mode, stdout_is_terminal, stderr_is_terminal) {
+    if !should_notify(out.interactive(), out.foreground(), stderr_is_terminal) {
         return;
     }
 
@@ -47,18 +45,16 @@ pub(crate) fn notify_once(feature: &BetaFeature) {
     }
 }
 
-fn should_notify(
-    output_mode: OutputMode,
-    stdout_is_terminal: bool,
-    stderr_is_terminal: bool,
-) -> bool {
-    output_mode.is_normal() && stdout_is_terminal && stderr_is_terminal
+/// The notice only goes out for a foreground CLI driving an interactive terminal:
+/// human output on a stdout TTY (never JSON or MCP capture), with stderr also a
+/// TTY so the notice itself is seen.
+fn should_notify(interactive: bool, foreground: bool, stderr_is_terminal: bool) -> bool {
+    interactive && foreground && stderr_is_terminal
 }
 
 #[cfg(test)]
 mod tests {
     use super::{should_notify, BetaFeature, STORAGE, STORAGE_BETA_MESSAGE};
-    use crate::output::OutputMode;
 
     #[test]
     fn short_about_has_one_beta_suffix() {
@@ -91,13 +87,14 @@ mod tests {
     }
 
     #[test]
-    fn notice_requires_normal_output_and_two_terminals() {
-        assert!(should_notify(OutputMode::Normal, true, true));
-        assert!(!should_notify(OutputMode::Normal, false, true));
-        assert!(!should_notify(OutputMode::Normal, true, false));
-        assert!(!should_notify(OutputMode::Normal, false, false));
-        assert!(!should_notify(OutputMode::Json, true, true));
-        assert!(!should_notify(OutputMode::McpStdio, true, true));
-        assert!(!should_notify(OutputMode::McpStreaming, true, true));
+    fn notice_requires_interactive_foreground_and_stderr_terminal() {
+        assert!(should_notify(true, true, true));
+        // stdout not an interactive terminal (redirected, JSON, or MCP capture)
+        assert!(!should_notify(false, true, true));
+        // not a foreground CLI (MCP or discarded output)
+        assert!(!should_notify(true, false, true));
+        // stderr not a terminal
+        assert!(!should_notify(true, true, false));
+        assert!(!should_notify(false, false, false));
     }
 }

--- a/crates/tower-cmd/src/catalogs.rs
+++ b/crates/tower-cmd/src/catalogs.rs
@@ -118,7 +118,7 @@ pub fn catalogs_cmd() -> Command {
         )
 }
 
-pub async fn do_list(config: Config, args: &ArgMatches) {
+pub async fn do_list(out: &output::Out, config: Config, args: &ArgMatches) {
     let all = cmd::get_bool_flag(args, "all");
     let env = cmd::get_string_flag(args, "environment");
     let catalog_type = if cmd::get_bool_flag(args, "storage") {
@@ -128,14 +128,15 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
     };
 
     if is_storage_catalog_type(catalog_type) {
-        beta::notify_once(&beta::STORAGE);
+        beta::notify_once(out, &beta::STORAGE);
     }
 
-    let catalogs = output::with_spinner(
-        "Listing catalogs",
-        api::list_catalogs(&config, &env, all, catalog_type),
-    )
-    .await;
+    let catalogs = out
+        .with_spinner(
+            "Listing catalogs",
+            api::list_catalogs(&config, &env, all, catalog_type),
+        )
+        .await;
 
     let headers = vec!["Name", "Type", "Environment"]
         .into_iter()
@@ -151,11 +152,11 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
             ]
         })
         .collect();
-    output::table(headers, data, Some(&catalogs));
+    out.table(headers, data, Some(&catalogs));
 }
 
-pub async fn do_credentials(config: Config, args: &ArgMatches) {
-    beta::notify_once(&beta::STORAGE);
+pub async fn do_credentials(out: &output::Out, config: Config, args: &ArgMatches) {
+    beta::notify_once(out, &beta::STORAGE);
 
     let name = args
         .get_one::<String>("catalog_name")
@@ -171,11 +172,12 @@ pub async fn do_credentials(config: Config, args: &ArgMatches) {
         .unwrap_or("all");
     let show_token = cmd::get_bool_flag(args, "show_token");
 
-    let response = output::with_spinner(
-        "Vending catalog credentials",
-        api::vend_catalog_credentials(&config, name, &env, parse_mode(mode)),
-    )
-    .await;
+    let response = out
+        .with_spinner(
+            "Vending catalog credentials",
+            api::vend_catalog_credentials(&config, name, &env, parse_mode(mode)),
+        )
+        .await;
 
     let human = credentials_text(
         name,
@@ -186,10 +188,10 @@ pub async fn do_credentials(config: Config, args: &ArgMatches) {
         format,
         show_token,
     );
-    output::text(&human, &response);
+    out.text(&human, &response);
 }
 
-pub async fn do_show(config: Config, args: &ArgMatches) {
+pub async fn do_show(out: &output::Out, config: Config, args: &ArgMatches) {
     let name = args
         .get_one::<String>("catalog_name")
         .expect("catalog_name is required");
@@ -198,12 +200,12 @@ pub async fn do_show(config: Config, args: &ArgMatches) {
     match api::describe_catalog(&config, name, &env).await {
         Ok(response) => {
             if is_storage_catalog_type(Some(&response.catalog.r#type)) {
-                beta::notify_once(&beta::STORAGE);
+                beta::notify_once(out, &beta::STORAGE);
             }
             let human = catalog_details_text(&response);
-            output::text(&human, &response);
+            out.text(&human, &response);
         }
-        Err(err) => output::tower_error_and_die(err, "Fetching catalog details failed"),
+        Err(err) => out.tower_error_and_die(err, "Fetching catalog details failed"),
     }
 }
 

--- a/crates/tower-cmd/src/deploy.rs
+++ b/crates/tower-cmd/src/deploy.rs
@@ -101,7 +101,7 @@ fn resolve_idempotency_key(args: &ArgMatches, dir: &Path) -> Option<String> {
     util::git::clean_head_sha(dir)
 }
 
-pub async fn do_deploy(config: Config, args: &ArgMatches) {
+pub async fn do_deploy(out: &output::Out, config: Config, args: &ArgMatches) {
     let dir = resolve_path(args);
     let create_app = args.get_flag("create");
     let idempotency_key = resolve_idempotency_key(args, &dir);
@@ -114,31 +114,32 @@ pub async fn do_deploy(config: Config, args: &ArgMatches) {
         DeployTarget::Environment("default".to_string())
     };
 
-    if let Err(err) = deploy_from_dir(config, dir, create_app, target, idempotency_key).await {
+    if let Err(err) = deploy_from_dir(out, config, dir, create_app, target, idempotency_key).await {
         match err {
             crate::Error::ApiDeployError { source } => {
-                output::tower_error_and_die(source, "Deploying app failed")
+                out.tower_error_and_die(source, "Deploying app failed")
             }
             crate::Error::ApiCreateAppError { source } => {
-                output::tower_error_and_die(source, "Creating app failed")
+                out.tower_error_and_die(source, "Creating app failed")
             }
             crate::Error::ApiDescribeAppError { source } => {
-                output::tower_error_and_die(source, "Fetching app details failed")
+                out.tower_error_and_die(source, "Fetching app details failed")
             }
             crate::Error::PackageError { source } => {
-                output::package_error(source);
+                out.package_error(source);
                 std::process::exit(1);
             }
             crate::Error::TowerfileLoadFailed { source, .. } => {
-                output::package_error(source);
+                out.package_error(source);
                 std::process::exit(1);
             }
-            _ => output::die(&err.to_string()),
+            _ => out.die(&err.to_string()),
         }
     }
 }
 
 pub async fn deploy_from_dir(
+    out: &output::Out,
     config: Config,
     dir: PathBuf,
     create_app: bool,
@@ -159,6 +160,7 @@ pub async fn deploy_from_dir(
 
     // Add app existence check before proceeding
     util::apps::ensure_app_exists(
+        out,
         &api_config,
         &towerfile.app.name,
         towerfile.app.description.as_deref(),
@@ -167,22 +169,31 @@ pub async fn deploy_from_dir(
     .await?;
 
     let spec = PackageSpec::from_towerfile(&towerfile);
-    let mut spinner = output::spinner("Building package...");
+    let mut spinner = out.spinner("Building package...");
 
     let package = match Package::build(spec).await {
         Ok(package) => package,
         Err(err) => {
-            spinner.failure();
+            spinner.failure(out);
             let error = crate::Error::PackageError { source: err };
             return Err(error);
         }
     };
 
-    spinner.success();
-    do_deploy_package(api_config, package, &towerfile, target, idempotency_key).await
+    spinner.success(out);
+    do_deploy_package(
+        out,
+        api_config,
+        package,
+        &towerfile,
+        target,
+        idempotency_key,
+    )
+    .await
 }
 
 async fn do_deploy_package(
+    out: &output::Out,
     api_config: Configuration,
     package: Package,
     towerfile: &Towerfile,
@@ -195,6 +206,7 @@ async fn do_deploy_package(
     };
 
     let res = util::deploy::deploy_app_package(
+        out,
         &api_config,
         &towerfile.app.name,
         package,
@@ -217,10 +229,10 @@ async fn do_deploy_package(
                     version.version, env
                 ),
             };
-            output::success(&line);
+            out.success(&line);
 
             if let Some(hint) = reuse_hint(&version, idempotency_key.as_deref()) {
-                output::muted(&hint);
+                out.muted(&hint);
             }
 
             Ok(())

--- a/crates/tower-cmd/src/environments.rs
+++ b/crates/tower-cmd/src/environments.rs
@@ -41,9 +41,10 @@ pub fn environments_cmd() -> Command {
         )
 }
 
-pub async fn do_list(config: Config) {
-    let environments =
-        output::with_spinner("Listing environments", api::list_environments(&config)).await;
+pub async fn do_list(out: &output::Out, config: Config) {
+    let environments = out
+        .with_spinner("Listing environments", api::list_environments(&config))
+        .await;
 
     let headers = vec!["Name".to_string()];
 
@@ -53,21 +54,21 @@ pub async fn do_list(config: Config) {
         .collect();
 
     // Display the table using the existing table function
-    output::table(headers, envs_data, Some(&environments));
+    out.table(headers, envs_data, Some(&environments));
 }
 
-pub async fn do_create(config: Config, args: &ArgMatches) {
+pub async fn do_create(out: &output::Out, config: Config, args: &ArgMatches) {
     let name = args.get_one::<String>("name").unwrap_or_else(|| {
-        output::die("Environment name (--name) is required");
+        out.die("Environment name (--name) is required");
     });
 
-    output::with_spinner(
+    out.with_spinner(
         "Creating environment",
         api::create_environment(&config, name),
     )
     .await;
 
-    output::success(&format!("Environment '{}' created", name));
+    out.success(&format!("Environment '{}' created", name));
 }
 
 fn env_resources_description(env: DescribeEnvironmentResponse) -> Option<String> {
@@ -88,24 +89,25 @@ fn env_resources_description(env: DescribeEnvironmentResponse) -> Option<String>
     return None;
 }
 
-pub async fn do_delete(config: Config, args: &ArgMatches) {
+pub async fn do_delete(out: &output::Out, config: Config, args: &ArgMatches) {
     let name = args.get_one::<String>("name").unwrap_or_else(|| {
-        output::die("Environment name (--name) is required");
+        out.die("Environment name (--name) is required");
     });
 
-    let env = output::with_spinner(
-        "Retrieving environment...",
-        api::describe_environment(&config, name),
-    )
-    .await;
+    let env = out
+        .with_spinner(
+            "Retrieving environment...",
+            api::describe_environment(&config, name),
+        )
+        .await;
 
     if !env.environment.is_deletable {
-        output::error(&format!("You cannot delete the {name} environment."));
+        out.error(&format!("You cannot delete the {name} environment."));
         return;
     }
 
     if let Some(desc) = env_resources_description(env) {
-        output::write(&format!("Warning! Your environment contains {desc}.\n"))
+        out.write(&format!("Warning! Your environment contains {desc}.\n"))
     }
 
     let ans = prompt::confirm(
@@ -115,20 +117,20 @@ pub async fn do_delete(config: Config, args: &ArgMatches) {
 
     match ans {
         Ok(true) => {
-            output::with_spinner(
+            out.with_spinner(
                 &format!("Deleting environment {name}"),
                 api::delete_environment(&config, name),
             )
             .await;
 
-            output::success(&format!("Environment '{name}' deleted"));
+            out.success(&format!("Environment '{name}' deleted"));
         }
-        Ok(false) => output::write("Aborting environment deletion.\n"),
+        Ok(false) => out.write("Aborting environment deletion.\n"),
         Err(prompt::Error::ConfirmationPromptCancelled) => {
-            output::write("Aborting environment deletion.\n")
+            out.write("Aborting environment deletion.\n")
         }
         Err(_) => {
-            output::error(
+            out.error(
                 "Something went wrong. Please try again, and contact us if the issue persists.",
             );
         }

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -83,9 +83,11 @@ impl App {
             config.clone()
         };
 
-        if config.json {
-            output::set_output_mode(output::OutputMode::Json);
-        }
+        let out = if config.json {
+            output::Out::json_stdout()
+        } else {
+            output::Out::human()
+        };
 
         if config.debug {
             // Set log level to "DEBUG"
@@ -120,18 +122,20 @@ impl App {
         }
 
         match matches.subcommand() {
-            Some(("login", args)) => session::do_login(config, args).await,
-            Some(("version", _)) => version::do_version().await,
+            Some(("login", args)) => session::do_login(&out, config, args).await,
+            Some(("version", _)) => version::do_version(&out).await,
             Some(("apps", sub_matches)) => {
                 let apps_command = sub_matches.subcommand();
 
                 match apps_command {
-                    Some(("list", args)) => apps::do_list_apps(sessionized_config, args).await,
-                    Some(("create", args)) => apps::do_create(sessionized_config, args).await,
-                    Some(("show", args)) => apps::do_show(sessionized_config, args).await,
-                    Some(("logs", args)) => apps::do_logs(sessionized_config, args).await,
-                    Some(("delete", args)) => apps::do_delete(sessionized_config, args).await,
-                    Some(("cancel", args)) => apps::do_cancel(sessionized_config, args).await,
+                    Some(("list", args)) => {
+                        apps::do_list_apps(&out, sessionized_config, args).await
+                    }
+                    Some(("create", args)) => apps::do_create(&out, sessionized_config, args).await,
+                    Some(("show", args)) => apps::do_show(&out, sessionized_config, args).await,
+                    Some(("logs", args)) => apps::do_logs(&out, sessionized_config, args).await,
+                    Some(("delete", args)) => apps::do_delete(&out, sessionized_config, args).await,
+                    Some(("cancel", args)) => apps::do_cancel(&out, sessionized_config, args).await,
                     _ => {
                         apps::apps_cmd().print_help().unwrap();
                         std::process::exit(2);
@@ -142,10 +146,10 @@ impl App {
                 let catalogs_command = sub_matches.subcommand();
 
                 match catalogs_command {
-                    Some(("list", args)) => catalogs::do_list(sessionized_config, args).await,
-                    Some(("show", args)) => catalogs::do_show(sessionized_config, args).await,
+                    Some(("list", args)) => catalogs::do_list(&out, sessionized_config, args).await,
+                    Some(("show", args)) => catalogs::do_show(&out, sessionized_config, args).await,
                     Some(("credentials", args)) => {
-                        catalogs::do_credentials(sessionized_config, args).await
+                        catalogs::do_credentials(&out, sessionized_config, args).await
                     }
                     _ => {
                         catalogs::catalogs_cmd().print_help().unwrap();
@@ -157,9 +161,13 @@ impl App {
                 let secrets_command = sub_matches.subcommand();
 
                 match secrets_command {
-                    Some(("list", args)) => secrets::do_list(sessionized_config, args).await,
-                    Some(("create", args)) => secrets::do_create(sessionized_config, args).await,
-                    Some(("delete", args)) => secrets::do_delete(sessionized_config, args).await,
+                    Some(("list", args)) => secrets::do_list(&out, sessionized_config, args).await,
+                    Some(("create", args)) => {
+                        secrets::do_create(&out, sessionized_config, args).await
+                    }
+                    Some(("delete", args)) => {
+                        secrets::do_delete(&out, sessionized_config, args).await
+                    }
                     _ => {
                         secrets::secrets_cmd().print_help().unwrap();
                         std::process::exit(2);
@@ -170,12 +178,12 @@ impl App {
                 let environments_command = sub_matches.subcommand();
 
                 match environments_command {
-                    Some(("list", _)) => environments::do_list(sessionized_config).await,
+                    Some(("list", _)) => environments::do_list(&out, sessionized_config).await,
                     Some(("create", args)) => {
-                        environments::do_create(sessionized_config, args).await
+                        environments::do_create(&out, sessionized_config, args).await
                     }
                     Some(("delete", args)) => {
-                        environments::do_delete(sessionized_config, args).await
+                        environments::do_delete(&out, sessionized_config, args).await
                     }
                     _ => {
                         environments::environments_cmd().print_help().unwrap();
@@ -186,25 +194,35 @@ impl App {
                 let schedules_command = sub_matches.subcommand();
 
                 match schedules_command {
-                    Some(("list", args)) => schedules::do_list(sessionized_config, args).await,
-                    Some(("create", args)) => schedules::do_create(sessionized_config, args).await,
-                    Some(("update", args)) => schedules::do_update(sessionized_config, args).await,
-                    Some(("delete", args)) => schedules::do_delete(sessionized_config, args).await,
+                    Some(("list", args)) => {
+                        schedules::do_list(&out, sessionized_config, args).await
+                    }
+                    Some(("create", args)) => {
+                        schedules::do_create(&out, sessionized_config, args).await
+                    }
+                    Some(("update", args)) => {
+                        schedules::do_update(&out, sessionized_config, args).await
+                    }
+                    Some(("delete", args)) => {
+                        schedules::do_delete(&out, sessionized_config, args).await
+                    }
                     _ => {
                         schedules::schedules_cmd().print_help().unwrap();
                         std::process::exit(2);
                     }
                 }
             }
-            Some(("deploy", args)) => deploy::do_deploy(sessionized_config, args).await,
-            Some(("package", args)) => package::do_package(sessionized_config, args).await,
-            Some(("run", args)) => run::do_run(sessionized_config, args).await,
+            Some(("deploy", args)) => deploy::do_deploy(&out, sessionized_config, args).await,
+            Some(("package", args)) => package::do_package(&out, sessionized_config, args).await,
+            Some(("run", args)) => run::do_run(&out, sessionized_config, args).await,
             Some(("teams", sub_matches)) => {
                 let teams_command = sub_matches.subcommand();
 
                 match teams_command {
-                    Some(("list", _)) => teams::do_list(sessionized_config).await,
-                    Some(("switch", args)) => teams::do_switch(sessionized_config, args).await,
+                    Some(("list", _)) => teams::do_list(&out, sessionized_config).await,
+                    Some(("switch", args)) => {
+                        teams::do_switch(&out, sessionized_config, args).await
+                    }
                     _ => {
                         teams::teams_cmd().print_help().unwrap();
                         std::process::exit(2);

--- a/crates/tower-cmd/src/mcp.rs
+++ b/crates/tower-cmd/src/mcp.rs
@@ -236,11 +236,10 @@ pub async fn do_mcp_server(config: Config, args: &clap::ArgMatches) -> Result<()
 }
 
 async fn run_stdio_server(config: Config) -> Result<(), Error> {
-    // Set stdio MCP mode to prevent any non-JSON-RPC output from corrupting the protocol
-    crate::output::set_output_mode(crate::output::OutputMode::McpStdio);
-
+    // stdio transport only collects tool output (no notifications) so nothing pollutes
+    // the JSON-RPC stream on stdout.
     let (stdin, stdout) = stdio();
-    let service = TowerService::new(config);
+    let service = TowerService::new(config, false);
     let server = service.serve((stdin, stdout)).await.map_err(|e| {
         Error::from(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -253,14 +252,11 @@ async fn run_stdio_server(config: Config) -> Result<(), Error> {
 
 async fn run_sse_server(config: Config, port: u16) -> Result<(), Error> {
     let bind_addr = format!("127.0.0.1:{}", port);
-    crate::output::write(&format!("SSE MCP server running on http://{}\n", bind_addr));
-
-    // Set streaming MCP mode to enable logging notifications
-    crate::output::set_output_mode(crate::output::OutputMode::McpStreaming);
+    println!("SSE MCP server running on http://{}", bind_addr);
 
     let ct = SseServer::serve(bind_addr.parse()?)
         .await?
-        .with_service_directly(move || TowerService::new(config.clone()));
+        .with_service_directly(move || TowerService::new(config.clone(), true));
 
     tokio::signal::ctrl_c().await?;
     ct.cancel();
@@ -269,16 +265,10 @@ async fn run_sse_server(config: Config, port: u16) -> Result<(), Error> {
 
 async fn run_http_server(config: Config, port: u16) -> Result<(), Error> {
     let bind_addr = format!("127.0.0.1:{}", port);
-    crate::output::write(&format!(
-        "Streamable HTTP MCP server running on http://{}\n",
-        bind_addr
-    ));
-
-    // Set streaming MCP mode to enable logging notifications
-    crate::output::set_output_mode(crate::output::OutputMode::McpStreaming);
+    println!("Streamable HTTP MCP server running on http://{}", bind_addr);
 
     let service = StreamableHttpService::new(
-        move || Ok(TowerService::new(config.clone())),
+        move || Ok(TowerService::new(config.clone(), true)),
         LocalSessionManager::default().into(),
         StreamableHttpServerConfig::default(),
     );
@@ -296,18 +286,24 @@ async fn run_http_server(config: Config, port: u16) -> Result<(), Error> {
 #[derive(Clone)]
 pub struct TowerService {
     config: Config,
+    /// Whether tool output should be streamed to the peer as logging notifications.
+    /// True for SSE/HTTP transports, false for stdio (which only collects output).
+    send_notifications: bool,
     tool_router: ToolRouter<Self>,
 }
 
 #[tool_router]
 impl TowerService {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, send_notifications: bool) -> Self {
+        // MCP output is captured as plain text, so disable ANSI colours globally.
+        colored::control::set_override(false);
         Self {
             config: std::env::var("TOWER_JWT")
                 .ok()
                 .and_then(|token| Session::from_jwt(&token).ok())
                 .map(|session| config.clone().with_session(session))
                 .unwrap_or(config),
+            send_notifications,
             tool_router: Self::tool_router(),
         }
     }
@@ -466,25 +462,23 @@ impl TowerService {
     }
 
     async fn execute_with_streaming<F, Fut, T>(
+        &self,
         ctx: &RequestContext<RoleServer>,
         operation: F,
     ) -> (Result<T, crate::Error>, String)
     where
-        F: FnOnce() -> Fut,
+        F: FnOnce(crate::output::Out) -> Fut,
         Fut: std::future::Future<Output = Result<T, crate::Error>>,
     {
-        // Check if we're in streaming mode (SSE/HTTP) where we send notifications
-        // vs stdio mode where we don't
-        let mode = crate::output::get_output_mode();
-        let send_notifications = mode == crate::output::OutputMode::McpStreaming;
-        let streaming = Self::setup_output_capture(ctx, send_notifications);
+        let streaming = Self::setup_output_capture(ctx, self.send_notifications);
 
-        crate::output::set_current_sender(streaming.sender.clone());
+        // The command writes through this `Out`; each line it produces is forwarded to
+        // the capture channel (and, in streaming mode, to the peer as a notification).
+        // The operation owns the `Out` and drops it when finished, which closes the
+        // channel so the drain task below can complete.
+        let out = crate::output::Out::mcp(streaming.sender);
+        let result = operation(out).await;
 
-        let result = operation().await;
-
-        crate::output::clear_current_sender();
-        drop(streaming.sender);
         streaming.task.await.ok();
 
         let output = streaming
@@ -817,7 +811,10 @@ impl TowerService {
         // collapse to a single AppVersion server-side.
         let idempotency_key = crate::util::git::clean_head_sha(&working_dir);
 
+        // The tool builds its own result message, so the deploy's own progress is discarded.
+        let out = crate::output::Out::sink();
         match deploy::deploy_from_dir(
+            &out,
             self.config.clone(),
             working_dir,
             true,
@@ -842,15 +839,17 @@ impl TowerService {
         let working_dir = Self::resolve_working_directory(&request.common);
         let config = self.config.clone();
 
-        let (result, output) = Self::execute_with_streaming(&ctx, || {
-            run::do_run_local(
-                config,
-                working_dir,
-                "default",
-                std::collections::HashMap::new(),
-            )
-        })
-        .await;
+        let (result, output) = self
+            .execute_with_streaming(&ctx, |out| {
+                run::do_run_local(
+                    out,
+                    config,
+                    working_dir,
+                    "default",
+                    std::collections::HashMap::new(),
+                )
+            })
+            .await;
         match result {
             Ok(_) => {
                 if output.trim().is_empty() {
@@ -894,10 +893,11 @@ impl TowerService {
 
         let app_name = towerfile.app.name.clone();
 
-        let (result, output) = Self::execute_with_streaming(&ctx, || {
-            run::do_run_remote(config, path, &env, params, None, true)
-        })
-        .await;
+        let (result, output) = self
+            .execute_with_streaming(&ctx, |out| {
+                run::do_run_remote(out, config, path, &env, params, None, true)
+            })
+            .await;
         match result {
             Ok(_) => {
                 if output.trim().is_empty() {

--- a/crates/tower-cmd/src/output.rs
+++ b/crates/tower-cmd/src/output.rs
@@ -1,13 +1,13 @@
 pub use cli_table::{format::Justify, Cell};
 use cli_table::{
     format::{Border, HorizontalLine, Separator},
-    print_stdout, Table, TableStruct,
+    Table, TableStruct,
 };
-use colored::{control, Colorize};
+use colored::Colorize;
 use http::StatusCode;
 use serde::Serialize;
-use std::io::{self, Write};
-use std::sync::{Mutex, OnceLock};
+use std::io::{self, IsTerminal, Write};
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedSender;
 use tower_api::{
     apis::{Error as ApiError, ResponseContent},
@@ -17,129 +17,510 @@ use tower_telemetry::debug;
 
 const BANNER_TEXT: &str = include_str!("./banner.txt");
 
+/// How results are rendered. `Human` produces the coloured, formatted output;
+/// `Json` produces machine-parseable JSON.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OutputMode {
-    /// Normal CLI output with colors and formatting
-    Normal,
-    /// JSON output mode
+pub enum Format {
+    Human,
     Json,
-    /// MCP server with stdio transport (no notifications, capture output)
-    McpStdio,
-    /// MCP server with streaming transport like SSE/HTTP (send notifications)
-    McpStreaming,
 }
 
-impl OutputMode {
-    pub fn is_mcp(self) -> bool {
-        matches!(self, Self::McpStdio | Self::McpStreaming)
-    }
-
-    pub fn is_json(self) -> bool {
-        matches!(self, Self::Json)
-    }
-
-    pub fn is_normal(self) -> bool {
-        matches!(self, Self::Normal)
-    }
+/// `Out` is the explicit output destination for a command. It carries the render
+/// format and the writer to send results to, so nothing needs to consult a global
+/// to decide where output goes. The CLI builds one over stdout; the MCP server
+/// builds one over a channel that forwards each line to the connected peer.
+///
+/// `Out` is cheap to clone and safe to send between tasks — clones share the same
+/// underlying writer through an `Arc<Mutex<_>>`, so a spawned task (e.g. a log
+/// monitor) can own a clone and write to the same destination as the foreground.
+#[derive(Clone)]
+pub struct Out {
+    format: Format,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    /// True only when driving an interactive terminal, where spinners animate.
+    /// False for JSON and for MCP capture.
+    interactive: bool,
+    /// True when this is a foreground CLI process that owns terminal signals
+    /// (so it may install a Ctrl+C handler). False for MCP/captured output.
+    foreground: bool,
 }
 
-static OUTPUT_MODE: OnceLock<OutputMode> = OnceLock::new();
-static CURRENT_SENDER: Mutex<Option<UnboundedSender<String>>> = Mutex::new(None);
-
-fn write_to_stdout(msg: &str) {
-    let mut stdout = io::stdout();
-    if let Err(err) = stdout.write_all(msg.as_bytes()) {
-        if err.kind() == io::ErrorKind::BrokenPipe {
-            std::process::exit(0);
-        }
-        panic!("failed writing to stdout: {err}");
-    }
-    stdout.flush().ok();
-}
-
-fn write_to_stderr(msg: &str) {
-    let mut stderr = io::stderr();
-    if let Err(err) = stderr.write_all(msg.as_bytes()) {
-        if err.kind() == io::ErrorKind::BrokenPipe {
-            std::process::exit(0);
-        }
-        panic!("failed writing to stderr: {err}");
-    }
-    stderr.flush().ok();
-}
-
-pub(crate) fn notice_to_stderr(label: &str, msg: &str) {
-    let line = format!("{} {}\n", label.bold().yellow(), msg);
-    write_to_stderr(&line);
-}
-
-pub fn set_output_mode(mode: OutputMode) {
-    OUTPUT_MODE.set(mode).ok();
-    if mode.is_mcp() {
-        control::set_override(false);
-    }
-}
-
-pub fn get_output_mode() -> OutputMode {
-    OUTPUT_MODE.get().copied().unwrap_or(OutputMode::Normal)
-}
-
-pub fn set_current_sender(sender: UnboundedSender<String>) {
-    *CURRENT_SENDER.lock().unwrap() = Some(sender);
-}
-
-pub fn clear_current_sender() {
-    *CURRENT_SENDER.lock().unwrap() = None;
-}
-
-fn send_to_current_sender(msg: String) {
-    if let Ok(sender_guard) = CURRENT_SENDER.lock() {
-        if let Some(tx) = sender_guard.as_ref() {
-            tx.send(msg).ok();
+impl Out {
+    fn new(
+        format: Format,
+        writer: Box<dyn Write + Send>,
+        interactive: bool,
+        foreground: bool,
+    ) -> Self {
+        Self {
+            format,
+            writer: Arc::new(Mutex::new(writer)),
+            interactive,
+            foreground,
         }
     }
-}
 
-pub fn json<T: Serialize>(data: &T) {
-    match serde_json::to_string_pretty(data) {
-        Ok(json_str) => {
-            write(&format!("{}\n", json_str));
+    /// Human-formatted output to stdout. Spinners animate when stdout is a TTY.
+    pub fn human() -> Self {
+        let interactive = io::stdout().is_terminal();
+        Self::new(Format::Human, Box::new(io::stdout()), interactive, true)
+    }
+
+    /// JSON output to stdout. No spinner animation so stdout stays parseable.
+    pub fn json_stdout() -> Self {
+        Self::new(Format::Json, Box::new(io::stdout()), false, true)
+    }
+
+    /// Output captured for an MCP tool call. Each written line is forwarded to the
+    /// supplied channel; the MCP server collects the lines and optionally streams
+    /// them to the peer as logging notifications.
+    pub fn mcp(sender: UnboundedSender<String>) -> Self {
+        Self::new(Format::Human, Box::new(McpWriter { sender }), false, false)
+    }
+
+    /// Output that goes nowhere. Used where a command emits progress that the caller
+    /// discards (e.g. the MCP deploy tool builds its own result message).
+    pub fn sink() -> Self {
+        Self::new(Format::Human, Box::new(io::sink()), false, false)
+    }
+
+    fn is_json(&self) -> bool {
+        self.format == Format::Json
+    }
+
+    /// Whether this process owns terminal signal handling (CLI foreground). MCP and
+    /// other captured outputs return false, so they don't trap Ctrl+C.
+    pub fn foreground(&self) -> bool {
+        self.foreground
+    }
+
+    /// Whether this output drives an interactive terminal: human format on a
+    /// stdout TTY. False for JSON, MCP capture, and redirected output.
+    pub fn interactive(&self) -> bool {
+        self.interactive
+    }
+
+    /// Writes raw text to the destination. On a broken pipe the process exits
+    /// cleanly, matching classic Unix tool behaviour.
+    pub fn write(&self, msg: &str) {
+        let mut writer = self.writer.lock().unwrap();
+        if let Err(err) = writer.write_all(msg.as_bytes()) {
+            if err.kind() == io::ErrorKind::BrokenPipe {
+                std::process::exit(0);
+            }
+            panic!("failed writing output: {err}");
         }
-        Err(e) => {
-            error(&format!("Failed to serialize to JSON: {}", e));
+        writer.flush().ok();
+    }
+
+    pub fn newline(&self) {
+        self.write("\n");
+    }
+
+    pub fn banner(&self) {
+        self.write(BANNER_TEXT);
+    }
+
+    fn json<T: Serialize>(&self, data: &T) {
+        match serde_json::to_string_pretty(data) {
+            Ok(json_str) => {
+                let line = format!("{}\n", json_str);
+                self.write(&line);
+            }
+            Err(e) => {
+                self.error(&format!("Failed to serialize to JSON: {}", e));
+            }
         }
     }
-}
 
-pub fn success(msg: &str) {
-    success_with_data(msg, None::<serde_json::Value>);
-}
+    pub fn success(&self, msg: &str) {
+        self.success_with_data(msg, None::<serde_json::Value>);
+    }
 
-pub fn muted(msg: &str) {
-    if get_output_mode().is_json() {
-        let response = serde_json::json!({
-            "result": "muted",
+    pub fn success_with_data<T: Serialize>(&self, msg: &str, data: Option<T>) {
+        let mut response = serde_json::json!({
+            "result": "success",
             "message": msg
         });
-        json(&response);
-    } else {
-        let line = msg.dimmed();
-        write(&line);
+
+        if let Some(data) = data {
+            response["data"] = serde_json::to_value(data).unwrap();
+        }
+
+        let line = format!("{} {}\n", "Success!".green(), msg);
+        self.text(&line, &response);
+    }
+
+    /// Writes a low-emphasis informational line, dimmed in human output.
+    pub fn muted(&self, msg: &str) {
+        if self.is_json() {
+            let response = serde_json::json!({
+                "result": "muted",
+                "message": msg
+            });
+            self.json(&response);
+        } else {
+            let line = format!("{}\n", msg.dimmed());
+            self.write(&line);
+        }
+    }
+
+    pub fn error(&self, msg: &str) {
+        if self.is_json() {
+            let response = serde_json::json!({
+                "result": "error",
+                "message": msg
+            });
+            self.json(&response);
+        } else {
+            let line = format!("{} {}\n", "Oh no!".red(), msg);
+            self.write(&line);
+        }
+    }
+
+    pub fn log_line(&self, timestamp: &str, message: &str, t: LogLineType) {
+        let line = format!("{} {}\n", format_timestamp(timestamp, t), message);
+        self.write(&line);
+    }
+
+    pub fn remote_log_event(&self, log: &tower_api::models::RunLogLine) {
+        let ts = crate::util::dates::format_str(&log.reported_at);
+        self.log_line(&ts, &log.content, LogLineType::Remote);
+    }
+
+    pub fn package_error(&self, err: tower_package::Error) {
+        let msg = match err {
+            tower_package::Error::NoManifest => "No manifest was found".to_string(),
+            tower_package::Error::InvalidManifest => {
+                "Invalid manifest was found or created".to_string()
+            }
+            tower_package::Error::InvalidPath => {
+                "There was a problem determining exactly where your Towerfile was stored on disk"
+                    .to_string()
+            }
+            tower_package::Error::InvalidGlob { message } => {
+                format!("Invalid file glob pattern: {}", message)
+            }
+            tower_package::Error::InvalidTowerfile { message } => {
+                format!("Invalid Towerfile: {}", message)
+            }
+            tower_package::Error::MissingTowerfile => {
+                "No Towerfile was found in the target directory".to_string()
+            }
+            tower_package::Error::MissingRequiredAppField { field } => {
+                format!("Missing required app field `{}` in Towerfile", field)
+            }
+            tower_package::Error::Io { source } => format!("IO error: {}", source),
+            tower_package::Error::MissingScript { script } => {
+                format!("Script '{}' not found. Check that the 'script' field in your Towerfile points to a file that exists in your project.", script)
+            }
+        };
+
+        let line = format!("{} {}\n", "Package error:".red(), msg);
+        self.write(&line);
+    }
+
+    pub fn config_error(&self, err: config::Error) {
+        let msg = match err {
+            config::Error::ConfigDirNotFound => "Config directory not found".to_string(),
+            config::Error::NoHomeDir => "No home directory found".to_string(),
+            config::Error::Io { ref source } => format!("IO error: {}", source),
+            config::Error::NoSession => "No session".to_string(),
+            config::Error::TeamNotFound { ref team_name } => {
+                format!("Team with name `{}` not found!", team_name)
+            }
+            config::Error::UnknownDescribeSessionValue { value: _ } => {
+                "An error occured while describing the session associated with the JWT you provided. Maybe your CLI is out of date?".to_string()
+            }
+            config::Error::DescribeSessionError { ref err } => {
+                format!("An error occured while describing the session associated with the JWT you provided: {}", err)
+            }
+        };
+
+        let line = format!("{} {}\n", "Config error:".red(), msg);
+        self.write(&line);
+    }
+
+    // Outputs both the model.detail and the model.errors fields in a human readable format.
+    fn output_full_error_details(&self, model: &ErrorModel) {
+        // Show the main detail message if available
+        if let Some(detail) = &model.detail {
+            self.write(&format!("\n{}\n", "Error details:".yellow()));
+            self.write(&format!("{}\n", detail.red()));
+        }
+
+        // Show any additional error details from the errors field
+        if let Some(errors) = &model.errors {
+            if !errors.is_empty() {
+                if model.detail.is_none() {
+                    self.write(&format!("\n{}\n", "Error details:".yellow()));
+                }
+                for error in errors {
+                    let msg = format!(
+                        "  • {}",
+                        error.message.as_deref().unwrap_or("Unknown error")
+                    );
+                    self.write(&format!("{}\n", msg.red()));
+                }
+            }
+        }
+    }
+
+    fn output_response_content_error<T>(&self, err: ResponseContent<T>) {
+        // Attempt to deserialize the error content into an ErrorModel.
+        let error_model = match serde_json::from_str::<ErrorModel>(&err.content) {
+            Ok(model) => {
+                debug!("Error model (status: {}): {:?}", err.status, model);
+                model
+            }
+            Err(e) => {
+                debug!("Failed to parse error content as JSON: {}", e);
+                debug!("Raw error content: {}", err.content);
+                // Show the raw error content if JSON parsing fails
+                self.write(&format!("\n{}\n", "API Error:".yellow()));
+                self.write(&format!("{}\n", err.content.red()));
+                return;
+            }
+        };
+
+        match err.status {
+            StatusCode::CONFLICT => {
+                self.output_full_error_details(&error_model);
+            }
+            StatusCode::UNPROCESSABLE_ENTITY => {
+                self.output_full_error_details(&error_model);
+            }
+            StatusCode::INTERNAL_SERVER_ERROR => {
+                self.error(
+                    "The Tower API encountered an internal error. Maybe try again later on.",
+                );
+            }
+            StatusCode::NOT_FOUND => {
+                self.output_full_error_details(&error_model);
+            }
+            StatusCode::UNAUTHORIZED => {
+                self.error(
+                    "You aren't authorized to do that! Are you logged in? Run `tower login` to login.",
+                );
+            }
+            _ => {
+                if error_model.detail.is_none() && error_model.errors.is_none() {
+                    self.error("The Tower API returned an error that the Tower CLI doesn't know what to do with! Maybe try again in a bit.");
+                }
+                self.output_full_error_details(&error_model);
+            }
+        }
+    }
+
+    fn tower_error<T>(&self, err: ApiError<T>) {
+        match err {
+            ApiError::ResponseError(resp) => {
+                self.output_response_content_error(resp);
+            }
+            ApiError::Reqwest(e) => {
+                debug!("Reqwest error: {:?}", e);
+                self.error("The Tower CLI wasn't able to talk to the Tower API! Are you offline? Try again later.");
+            }
+            ApiError::Serde(e) => {
+                debug!("Serde error: {:?}", e);
+                self.error("The Tower API returned something that the Tower CLI didn't understand. Maybe you need to upgrade Tower CLI?");
+            }
+            ApiError::Io(e) => {
+                debug!("Io error: {:?}", e);
+                self.error("An error happened while talking to the Tower API. You can try that again in a bit.");
+            }
+        }
+    }
+
+    /// Handles Tower API errors with context-specific authentication messages.
+    /// If the error is a 401 Unauthorized, provides a helpful message mentioning
+    /// the operation that failed and suggests running 'tower login'.
+    /// Always exits the process with error code 1.
+    pub fn tower_error_and_die<T>(&self, err: ApiError<T>, operation: &str) -> ! {
+        // Check if this is an authentication error
+        if let ApiError::ResponseError(ref resp) = err {
+            if resp.status == StatusCode::UNAUTHORIZED {
+                self.die(&format!(
+                    "{} because you are not logged into Tower. Please run 'tower login' first.",
+                    operation
+                ));
+            }
+        }
+
+        // Show the detailed error first
+        self.tower_error(err);
+        self.die(operation);
+    }
+
+    pub fn table<T: Serialize>(
+        &self,
+        headers: Vec<String>,
+        data: Vec<Vec<String>>,
+        json_data: Option<&T>,
+    ) {
+        if self.is_json() {
+            if let Some(data) = json_data {
+                self.json(data);
+            } else {
+                // Fallback: convert table data to JSON structure
+                let json_output: Vec<serde_json::Map<String, serde_json::Value>> = data
+                    .iter()
+                    .map(|row| {
+                        let mut obj = serde_json::Map::new();
+                        for (i, value) in row.iter().enumerate() {
+                            let key = headers
+                                .get(i)
+                                .expect("header should have same number of columns as row");
+                            obj.insert(key.to_string(), serde_json::Value::String(value.clone()));
+                        }
+                        obj
+                    })
+                    .collect();
+                self.json(&json_output);
+            }
+        } else {
+            let line = format!("{}\n", table_text(headers, data));
+            self.write(&line);
+        }
+    }
+
+    pub fn list<T: Serialize>(&self, items: Vec<String>, json_data: Option<&T>) {
+        if self.is_json() {
+            if let Some(data) = json_data {
+                self.json(data);
+            } else {
+                self.json(&items);
+            }
+        } else {
+            for item in items {
+                let line = format!(" * {}\n", item);
+                let line = line.replace("\n", "\n   ");
+                let line = format!("{}\n", line);
+                self.write(&line);
+            }
+        }
+    }
+
+    /// Writes a human-readable rendering of some data, or the data itself as JSON when
+    /// in JSON mode. Use this when a command's output is data that has both a plain text
+    /// and a JSON representation, mirroring `table` and `list`.
+    pub fn text<T: Serialize>(&self, msg: &str, json_data: &T) {
+        if self.is_json() {
+            self.json(json_data);
+        } else {
+            self.write(msg);
+        }
+    }
+
+    /// Writes presentation-only text that accompanies human-formatted output, like table
+    /// legends or hints. Suppressed in JSON mode so stdout stays machine-parseable.
+    pub fn note(&self, msg: &str) {
+        if !self.is_json() {
+            self.write(msg);
+        }
+    }
+
+    pub fn die(&self, msg: &str) -> ! {
+        io::stdout().flush().ok();
+        io::stderr().flush().ok();
+        let line = format!("{} {}\n", "Error:".red(), msg);
+        self.write(&line);
+        // Flush output before exit to ensure "Error:" message is displayed
+        io::stdout().flush().ok();
+        io::stderr().flush().ok();
+        std::process::exit(1);
+    }
+
+    /// Starts a spinner for a long running task. It animates only on an interactive
+    /// terminal; otherwise its completion messages are written like any other line so
+    /// they are still captured (e.g. by the MCP server).
+    pub fn spinner(&self, msg: &str) -> Spinner {
+        let anim = if self.interactive {
+            Some(spinners::Spinner::new(
+                spinners::Spinners::Dots,
+                msg.to_string(),
+            ))
+        } else {
+            None
+        };
+        Spinner {
+            msg: msg.to_string(),
+            anim,
+        }
+    }
+
+    /// Runs an async operation with a spinner and proper error handling.
+    ///
+    /// - Shows a spinner with "{operation}..." while the operation runs
+    /// - On success: stops the spinner with success indicator and returns the result
+    /// - On error: stops the spinner with failure indicator and shows an auth-aware
+    ///   error message, then exits the process.
+    pub async fn with_spinner<F, T, E>(&self, operation: &str, future: F) -> T
+    where
+        F: std::future::Future<Output = Result<T, ApiError<E>>>,
+    {
+        let spinner_msg = format!("{}...", operation);
+        let mut spinner = self.spinner(&spinner_msg);
+        match future.await {
+            Ok(result) => {
+                spinner.success(self);
+                result
+            }
+            Err(err) => {
+                spinner.failure(self);
+                let error_msg = format!("{} failed", operation);
+                self.tower_error_and_die(err, &error_msg);
+            }
+        }
+    }
+
+    /// The MCP-safe version of `with_spinner`: returns errors instead of exiting.
+    /// Use this for operations that may be called from MCP or other contexts where
+    /// process exit is not acceptable. Returns the error without displaying it, so
+    /// the caller decides how to handle and display it.
+    pub async fn try_with_spinner<F, T, E>(
+        &self,
+        operation: &str,
+        future: F,
+    ) -> Result<T, ApiError<E>>
+    where
+        F: std::future::Future<Output = Result<T, ApiError<E>>>,
+    {
+        let spinner_msg = format!("{}...", operation);
+        let mut spinner = self.spinner(&spinner_msg);
+        match future.await {
+            Ok(result) => {
+                spinner.success(self);
+                Ok(result)
+            }
+            Err(err) => {
+                spinner.failure(self);
+                // Just return the error - let the caller decide how to handle it
+                Err(err)
+            }
+        }
     }
 }
 
-pub fn success_with_data<T: Serialize>(msg: &str, data: Option<T>) {
-    let mut response = serde_json::json!({
-        "result": "success",
-        "message": msg
-    });
+/// A writer that forwards each written chunk to an MCP channel as one message
+/// (trailing whitespace trimmed). This replaces the previous global sender: the
+/// destination now lives in the `Out`.
+struct McpWriter {
+    sender: UnboundedSender<String>,
+}
 
-    if let Some(data) = data {
-        response["data"] = serde_json::to_value(data).unwrap();
+impl Write for McpWriter {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        let text = String::from_utf8_lossy(data).trim_end().to_string();
+        if !text.is_empty() {
+            self.sender.send(text).ok();
+        }
+        Ok(data.len())
     }
 
-    let line = format!("{} {}\n", "Success!".green(), msg);
-    text(&line, &response);
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 pub enum LogLineType {
@@ -156,58 +537,6 @@ fn format_timestamp(timestamp: &str, t: LogLineType) -> String {
         LogLineType::Remote => format!("{} {}", ts.yellow(), sep.yellow()),
         LogLineType::Local => format!("{} {}", ts.green(), sep.green()),
     }
-}
-
-pub fn log_line(timestamp: &str, message: &str, t: LogLineType) {
-    let line = format!("{} {}\n", format_timestamp(timestamp, t), message);
-    write(&line);
-}
-
-pub fn remote_log_event(log: &tower_api::models::RunLogLine) {
-    let ts = crate::util::dates::format_str(&log.reported_at);
-    log_line(&ts, &log.content, LogLineType::Remote);
-}
-
-pub fn package_error(err: tower_package::Error) {
-    let msg = match err {
-        tower_package::Error::NoManifest => "No manifest was found".to_string(),
-        tower_package::Error::InvalidManifest => {
-            "Invalid manifest was found or created".to_string()
-        }
-        tower_package::Error::InvalidPath => {
-            "There was a problem determining exactly where your Towerfile was stored on disk"
-                .to_string()
-        }
-        tower_package::Error::InvalidGlob { message } => {
-            format!("Invalid file glob pattern: {}", message)
-        }
-        tower_package::Error::InvalidTowerfile { message } => {
-            format!("Invalid Towerfile: {}", message)
-        }
-        tower_package::Error::MissingTowerfile => {
-            "No Towerfile was found in the target directory".to_string()
-        }
-        tower_package::Error::MissingRequiredAppField { field } => {
-            format!("Missing required app field `{}` in Towerfile", field)
-        }
-        tower_package::Error::Io { source } => format!("IO error: {}", source),
-        tower_package::Error::MissingScript { script } => {
-            format!("Script '{}' not found. Check that the 'script' field in your Towerfile points to a file that exists in your project.", script)
-        }
-    };
-
-    let line = format!("{} {}\n", "Package error:".red(), msg);
-    write(&line);
-}
-
-pub fn header(text: &str) {
-    let line = format!("{}\n", text.bold().green());
-    write(&line);
-}
-
-pub fn detail(label: &str, value: &str) {
-    let line = format!("{} {}\n", format!("{}:", label).bold().green(), value);
-    write(&line);
 }
 
 pub fn title(text: &str) -> String {
@@ -228,224 +557,6 @@ pub fn paragraph(msg: &str) -> String {
         .join("\n")
 }
 
-pub fn config_error(err: config::Error) {
-    let msg = match err {
-        config::Error::ConfigDirNotFound => "Config directory not found".to_string(),
-        config::Error::NoHomeDir => "No home directory found".to_string(),
-        config::Error::Io { ref source } => format!("IO error: {}", source),
-        config::Error::NoSession => "No session".to_string(),
-        config::Error::TeamNotFound { ref team_name } => {
-            format!("Team with name `{}` not found!", team_name)
-        }
-        config::Error::UnknownDescribeSessionValue { value: _ } => {
-            "An error occured while describing the session associated with the JWT you provided. Maybe your CLI is out of date?".to_string()
-        }
-        config::Error::DescribeSessionError { ref err } => {
-            format!("An error occured while describing the session associated with the JWT you provided: {}", err)
-        }
-    };
-
-    let line = format!("{} {}\n", "Config error:".red(), msg);
-    write(&line);
-}
-
-pub fn write(msg: &str) {
-    if get_output_mode().is_mcp() {
-        let clean_msg = msg.trim_end().to_string();
-        send_to_current_sender(clean_msg);
-    } else {
-        write_to_stdout(msg);
-    }
-}
-
-pub fn error(msg: &str) {
-    if get_output_mode().is_json() {
-        let response = serde_json::json!({
-            "result": "error",
-            "message": msg
-        });
-        json(&response);
-    } else {
-        let line = format!("{} {}\n", "Oh no!".red(), msg);
-        write(&line);
-    }
-}
-
-pub fn runtime_error(err: tower_runtime::errors::Error) {
-    let line = format!("{} {}\n", "Runtime Error:".red(), err.to_string());
-    write(&line);
-}
-
-// Outputs both the model.detail and the model.errors fields in a human readable format.
-pub fn output_full_error_details(model: &ErrorModel) {
-    // Show the main detail message if available
-    if let Some(detail) = &model.detail {
-        write(&format!("\n{}\n", "Error details:".yellow()));
-        write(&format!("{}\n", detail.red()));
-    }
-
-    // Show any additional error details from the errors field
-    if let Some(errors) = &model.errors {
-        if !errors.is_empty() {
-            if model.detail.is_none() {
-                write(&format!("\n{}\n", "Error details:".yellow()));
-            }
-            for error in errors {
-                let msg = format!(
-                    "  • {}",
-                    error.message.as_deref().unwrap_or("Unknown error")
-                );
-                write(&format!("{}\n", msg.red()));
-            }
-        }
-    }
-}
-
-fn output_response_content_error<T>(err: ResponseContent<T>) {
-    // Attempt to deserialize the error content into an ErrorModel.
-    let error_model = match serde_json::from_str::<ErrorModel>(&err.content) {
-        Ok(model) => {
-            debug!("Error model (status: {}): {:?}", err.status, model);
-            model
-        }
-        Err(e) => {
-            debug!("Failed to parse error content as JSON: {}", e);
-            debug!("Raw error content: {}", err.content);
-            // Show the raw error content if JSON parsing fails
-            write(&format!("\n{}\n", "API Error:".yellow()));
-            write(&format!("{}\n", err.content.red()));
-            return;
-        }
-    };
-
-    match err.status {
-        StatusCode::CONFLICT => {
-            output_full_error_details(&error_model);
-        }
-        StatusCode::UNPROCESSABLE_ENTITY => {
-            output_full_error_details(&error_model);
-        }
-        StatusCode::INTERNAL_SERVER_ERROR => {
-            error("The Tower API encountered an internal error. Maybe try again later on.");
-        }
-        StatusCode::NOT_FOUND => {
-            output_full_error_details(&error_model);
-        }
-        StatusCode::UNAUTHORIZED => {
-            error(
-                "You aren't authorized to do that! Are you logged in? Run `tower login` to login.",
-            );
-        }
-        _ => {
-            if error_model.detail.is_none() && error_model.errors.is_none() {
-                error("The Tower API returned an error that the Tower CLI doesn't know what to do with! Maybe try again in a bit.");
-            }
-            output_full_error_details(&error_model);
-        }
-    }
-}
-
-pub fn tower_error<T>(err: ApiError<T>) {
-    match err {
-        ApiError::ResponseError(resp) => {
-            output_response_content_error(resp);
-        }
-        ApiError::Reqwest(e) => {
-            debug!("Reqwest error: {:?}", e);
-            error("The Tower CLI wasn't able to talk to the Tower API! Are you offline? Try again later.");
-        }
-        ApiError::Serde(e) => {
-            debug!("Serde error: {:?}", e);
-            error("The Tower API returned something that the Tower CLI didn't understand. Maybe you need to upgrade Tower CLI?");
-        }
-        ApiError::Io(e) => {
-            debug!("Io error: {:?}", e);
-            error("An error happened while talking to the Tower API. You can try that again in a bit.");
-        }
-    }
-}
-
-/// Handles Tower API errors with context-specific authentication messages.
-/// If the error is a 401 Unauthorized, provides a helpful message mentioning
-/// the operation that failed and suggests running 'tower login'.
-/// Always exits the process with error code 1.
-pub fn tower_error_and_die<T>(err: ApiError<T>, operation: &str) -> ! {
-    // Check if this is an authentication error
-    if let ApiError::ResponseError(ref resp) = err {
-        if resp.status == StatusCode::UNAUTHORIZED {
-            die(&format!(
-                "{} because you are not logged into Tower. Please run 'tower login' first.",
-                operation
-            ));
-        }
-    }
-
-    // Show the detailed error first
-    tower_error(err);
-    die(operation);
-}
-
-/// Runs an async operation with a spinner and proper error handling.
-///
-/// This helper provides consistent spinner behavior across all commands:
-/// - Shows a spinner with "{operation}..." while the operation runs
-/// - On success: stops the spinner with success indicator and returns the result
-/// - On error: stops the spinner with failure indicator and shows auth-aware error message
-///
-/// # Examples
-///
-/// ```ignore
-/// let envs = output::with_spinner(
-///     "Listing environments",
-///     api::list_environments(&config)
-/// ).await;
-/// ```
-pub async fn with_spinner<F, T, E>(operation: &str, future: F) -> T
-where
-    F: std::future::Future<Output = Result<T, ApiError<E>>>,
-{
-    let spinner_msg = format!("{}...", operation);
-    let mut spinner = self::spinner(&spinner_msg);
-    match future.await {
-        Ok(result) => {
-            spinner.success();
-            result
-        }
-        Err(err) => {
-            spinner.failure();
-            let error_msg = format!("{} failed", operation);
-            tower_error_and_die(err, &error_msg);
-        }
-    }
-}
-
-/// Runs an async operation with a spinner, returning Result instead of exiting.
-///
-/// This is the MCP-safe version of with_spinner that returns errors instead of exiting.
-/// Use this for operations that may be called from MCP or other contexts where
-/// process exit is not acceptable. Returns the error without displaying it, allowing
-/// the caller to decide how to handle and display the error.
-///
-/// Shows "{operation}..." during execution and stops the spinner on completion.
-pub async fn try_with_spinner<F, T, E>(operation: &str, future: F) -> Result<T, ApiError<E>>
-where
-    F: std::future::Future<Output = Result<T, ApiError<E>>>,
-{
-    let spinner_msg = format!("{}...", operation);
-    let mut spinner = self::spinner(&spinner_msg);
-    match future.await {
-        Ok(result) => {
-            spinner.success();
-            Ok(result)
-        }
-        Err(err) => {
-            spinner.failure();
-            // Just return the error - let the caller decide how to handle it
-            Err(err)
-        }
-    }
-}
-
 fn formatted_table(headers: Vec<String>, data: Vec<Vec<String>>) -> TableStruct {
     let separator = Separator::builder()
         .title(Some(HorizontalLine::default()))
@@ -464,120 +575,62 @@ pub fn table_text(headers: Vec<String>, data: Vec<Vec<String>>) -> String {
     }
 }
 
-pub fn table<T: Serialize>(headers: Vec<String>, data: Vec<Vec<String>>, json_data: Option<&T>) {
-    if get_output_mode().is_json() {
-        if let Some(data) = json_data {
-            json(data);
-        } else {
-            // Fallback: convert table data to JSON structure
-            let json_output: Vec<serde_json::Map<String, serde_json::Value>> = data
-                .iter()
-                .map(|row| {
-                    let mut obj = serde_json::Map::new();
-                    for (i, value) in row.iter().enumerate() {
-                        let key = headers
-                            .get(i)
-                            .expect("header should have same number of columns as row");
-                        obj.insert(key.to_string(), serde_json::Value::String(value.clone()));
-                    }
-                    obj
-                })
-                .collect();
-            json(&json_output);
-        }
-    } else {
-        let table = formatted_table(headers, data);
-
-        if let Err(err) = print_stdout(table) {
-            if err.kind() == io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-            panic!("failed writing table to stdout: {err}");
-        }
-    }
-}
-
-pub fn list<T: Serialize>(items: Vec<String>, json_data: Option<&T>) {
-    if get_output_mode().is_json() {
-        if let Some(data) = json_data {
-            json(data);
-        } else {
-            json(&items);
-        }
-    } else {
-        for item in items {
-            let line = format!(" * {}\n", item);
-            let line = line.replace("\n", "\n   ");
-            let line = format!("{}\n", line);
-            write(&line);
-        }
-    }
-}
-
-/// Writes a human-readable rendering of some data, or the data itself as JSON when
-/// in JSON mode. Use this when a command's output is data that has both a plain text
-/// and a JSON representation, mirroring `table` and `list`.
-pub fn text<T: Serialize>(msg: &str, json_data: &T) {
-    if get_output_mode().is_json() {
-        json(json_data);
-    } else {
-        write(msg);
-    }
-}
-
-/// Writes presentation-only text that accompanies human-formatted output, like table
-/// legends or hints. Suppressed in JSON mode so stdout stays machine-parseable.
-pub fn note(msg: &str) {
-    if !get_output_mode().is_json() {
-        write(msg);
-    }
-}
-
-pub fn banner() {
-    write(&BANNER_TEXT);
-}
-
 pub struct Spinner {
     msg: String,
-    spinner: Option<spinners::Spinner>,
+    anim: Option<spinners::Spinner>,
 }
 
 impl Spinner {
-    pub fn new(msg: String) -> Spinner {
-        if get_output_mode().is_normal() {
-            let spinner = spinners::Spinner::new(spinners::Spinners::Dots, msg.clone());
-            Spinner {
-                spinner: Some(spinner),
-                msg,
-            }
-        } else {
-            Spinner { spinner: None, msg }
-        }
-    }
-
-    pub fn success(&mut self) {
-        if let Some(ref mut spinner) = self.spinner {
+    pub fn success(&mut self, out: &Out) {
+        if let Some(ref mut spinner) = self.anim {
             let sym = "✔".bold().green().to_string();
             spinner.stop_and_persist(&sym, format!("{} Done!", self.msg));
-        } else if get_output_mode().is_mcp() {
-            send_to_current_sender(format!("{} Done!", self.msg));
+        } else if out.format == Format::Human {
+            out.write(&format!("{} Done!\n", self.msg));
         }
     }
 
-    pub fn failure(&mut self) {
-        if let Some(ref mut spinner) = self.spinner {
+    pub fn failure(&mut self, out: &Out) {
+        if let Some(ref mut spinner) = self.anim {
             let sym = "✘".bold().red().to_string();
             spinner.stop_and_persist(&sym, format!("{} Failed!", self.msg));
-        } else if get_output_mode().is_mcp() {
-            send_to_current_sender(format!("{} Failed!", self.msg));
+        } else if out.format == Format::Human {
+            out.write(&format!("{} Failed!\n", self.msg));
         }
     }
 }
 
-/// spinner starts and returns a Spinner object. This is useful for long running tasks where you
-/// want to demonstrate there's something happening.
-pub fn spinner(msg: &str) -> Spinner {
-    Spinner::new(msg.into())
+/// Reports a fatal CLI usage error (such as a missing required flag) and exits.
+/// Used during argument parsing, before a command's `Out` is in play.
+pub fn die_usage(msg: &str) -> ! {
+    let line = format!("{} {}\n", "Error:".red(), msg);
+    let mut stdout = io::stdout();
+    let _ = stdout.write_all(line.as_bytes());
+    let _ = stdout.flush();
+    std::process::exit(1);
+}
+
+/// Writes a diagnostic error to stderr. For background tasks that have no `Out`
+/// handle to write through (e.g. a spawned run-completion monitor).
+pub fn background_error(msg: &str) {
+    write_to_stderr(&format!("{} {}\n", "Oh no!".red(), msg));
+}
+
+/// Writes a labelled notice to stderr, keeping stdout clean for command output.
+pub(crate) fn notice_to_stderr(label: &str, msg: &str) {
+    let line = format!("{} {}\n", label.bold().yellow(), msg);
+    write_to_stderr(&line);
+}
+
+fn write_to_stderr(msg: &str) {
+    let mut stderr = io::stderr();
+    if let Err(err) = stderr.write_all(msg.as_bytes()) {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            std::process::exit(0);
+        }
+        panic!("failed writing to stderr: {err}");
+    }
+    stderr.flush().ok();
 }
 
 pub fn write_update_available_message(latest: &str, current: &str) {
@@ -606,23 +659,6 @@ pub fn write_dev_version_message(current: &str, latest: &str) {
     );
 
     write_to_stderr(&line);
-}
-
-/// newline just outputs a newline. This is useful when you have a very specific formatting you
-/// want to maintain and you don't want to use println!.
-pub fn newline() {
-    write("\n");
-}
-
-pub fn die(msg: &str) -> ! {
-    io::stdout().flush().ok();
-    io::stderr().flush().ok();
-    let line = format!("{} {}\n", "Error:".red(), msg);
-    write(&line);
-    // Flush output before exit to ensure "Error:" message is displayed
-    io::stdout().flush().ok();
-    io::stderr().flush().ok();
-    std::process::exit(1);
 }
 
 pub struct ProgressBar {

--- a/crates/tower-cmd/src/package.rs
+++ b/crates/tower-cmd/src/package.rs
@@ -3,7 +3,6 @@ use config::{Config, Towerfile};
 use std::path::PathBuf;
 use tokio::fs;
 
-use crate::output;
 use tower_package::{Package, PackageSpec};
 use tower_telemetry::debug;
 
@@ -28,7 +27,7 @@ pub fn package_cmd() -> Command {
         .about("Create a package tar.gz file from your app without deploying")
 }
 
-pub async fn do_package(_config: Config, args: &ArgMatches) {
+pub async fn do_package(out: &crate::output::Out, _config: Config, args: &ArgMatches) {
     // Determine the directory to build the package from
     let dir = PathBuf::from(
         args.get_one::<String>("dir")
@@ -41,11 +40,11 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
     match Towerfile::from_path(path) {
         Ok(towerfile) => {
             let spec = PackageSpec::from_towerfile(&towerfile);
-            let mut spinner = output::spinner("Building package...");
+            let mut spinner = out.spinner("Building package...");
 
             match Package::build(spec).await {
                 Ok(package) => {
-                    spinner.success();
+                    spinner.success(out);
 
                     // Get the output path
                     let output_path = args
@@ -55,24 +54,21 @@ pub async fn do_package(_config: Config, args: &ArgMatches) {
                     // Save the package
                     match save_package(&package, output_path).await {
                         Ok(_) => {
-                            output::success(&format!(
-                                "Package created successfully: {}",
-                                output_path
-                            ));
+                            out.success(&format!("Package created successfully: {}", output_path));
                         }
                         Err(err) => {
-                            output::error(&format!("Failed to save package: {}", err));
+                            out.error(&format!("Failed to save package: {}", err));
                         }
                     }
                 }
                 Err(err) => {
-                    spinner.failure();
-                    output::package_error(err);
+                    spinner.failure(out);
+                    out.package_error(err);
                 }
             }
         }
         Err(err) => {
-            output::package_error(err);
+            out.package_error(err);
         }
     }
 }

--- a/crates/tower-cmd/src/run.rs
+++ b/crates/tower-cmd/src/run.rs
@@ -77,8 +77,8 @@ pub fn run_cmd() -> Command {
         .about("Run your code in Tower or locally")
 }
 
-pub async fn do_run(config: Config, args: &ArgMatches) {
-    if let Err(e) = do_run_inner(config, args).await {
+pub async fn do_run(out: &output::Out, config: Config, args: &ArgMatches) {
+    if let Err(e) = do_run_inner(out, config, args).await {
         match e {
             Error::ApiRunError { ref source } => {
                 let is_not_found = matches!(
@@ -86,7 +86,7 @@ pub async fn do_run(config: Config, args: &ArgMatches) {
                     tower_api::apis::Error::ResponseError(resp) if resp.status == reqwest::StatusCode::NOT_FOUND
                 );
                 if is_not_found {
-                    output::error(concat!(
+                    out.error(concat!(
                         "App not found. It may not exist or hasn't been deployed yet.\n",
                         "\n",
                         "To fix this:\n",
@@ -97,12 +97,12 @@ pub async fn do_run(config: Config, args: &ArgMatches) {
                     std::process::exit(1);
                 }
                 if let Error::ApiRunError { source } = e {
-                    output::tower_error_and_die(source, "Scheduling run failed");
+                    out.tower_error_and_die(source, "Scheduling run failed");
                 }
                 unreachable!();
             }
             _ => {
-                output::die(&e.to_string());
+                out.die(&e.to_string());
             }
         }
     }
@@ -110,8 +110,12 @@ pub async fn do_run(config: Config, args: &ArgMatches) {
 
 /// do_run is the primary entrypoint into running apps both locally and remotely in Tower. It will
 /// use the configuration to determine the requested way of running a Tower app.
-pub async fn do_run_inner(config: Config, args: &ArgMatches) -> Result<(), Error> {
-    let res = get_run_parameters(args);
+pub async fn do_run_inner(
+    out: &output::Out,
+    config: Config,
+    args: &ArgMatches,
+) -> Result<(), Error> {
+    let res = get_run_parameters(out, args);
 
     // We always expect there to be an environment due to the fact that there is a
     // default value.
@@ -128,13 +132,13 @@ pub async fn do_run_inner(config: Config, args: &ArgMatches) -> Result<(), Error
             if local {
                 // For the time being, we should report that we can't run an app by name locally.
                 if app_name.is_some() {
-                    output::die("Running apps by name locally is not supported yet.");
+                    out.die("Running apps by name locally is not supported yet.");
                 } else {
-                    do_run_local(config, path, env, params).await
+                    do_run_local(out.clone(), config, path, env, params).await
                 }
             } else {
                 let follow = should_follow_run(args);
-                do_run_remote(config, path, env, params, app_name, follow).await
+                do_run_remote(out.clone(), config, path, env, params, app_name, follow).await
             }
         }
         Err(err) => Err(err.into()),
@@ -143,6 +147,7 @@ pub async fn do_run_inner(config: Config, args: &ArgMatches) -> Result<(), Error
 
 /// Core implementation for running an app locally with configurable output handling
 async fn do_run_local_impl<F, Fut, T>(
+    out: &output::Out,
     config: Config,
     path: PathBuf,
     env: &str,
@@ -155,25 +160,25 @@ where
     T: Send + 'static,
 {
     // Load all the secrets and catalogs from the server
-    let mut spinner = output::spinner("Setting up runtime environment...");
+    let mut spinner = out.spinner("Setting up runtime environment...");
 
     let secrets = match get_secrets(&config, &env).await {
         Ok(s) => s,
         Err(err) => {
-            spinner.failure();
-            output::tower_error_and_die(err, "Fetching secrets failed");
+            spinner.failure(out);
+            out.tower_error_and_die(err, "Fetching secrets failed");
         }
     };
 
     let catalogs = match get_catalogs(&config, &env).await {
         Ok(c) => c,
         Err(err) => {
-            spinner.failure();
-            output::tower_error_and_die(err, "Fetching catalogs failed");
+            spinner.failure(out);
+            out.tower_error_and_die(err, "Fetching catalogs failed");
         }
     };
 
-    spinner.success();
+    spinner.success(out);
 
     // We prepare all the other misc environment variables that we need to inject
     let mut env_vars = HashMap::new();
@@ -198,8 +203,8 @@ where
     }
 
     // Build the package (creates tar.gz)
-    let package = build_package(&towerfile).await?;
-    output::success(&format!("Launching app `{}`", towerfile.app.name));
+    let package = build_package(out, &towerfile).await?;
+    out.success(&format!("Launching app `{}`", towerfile.app.name));
 
     // Open the tar.gz file as a stream
     let package_path = package
@@ -232,7 +237,7 @@ where
 
     // Monitor app status concurrently
     let handle = Arc::new(Mutex::new(handle));
-    let status_task = tokio::spawn(monitor_cli_status(Arc::clone(&handle)));
+    let status_task = tokio::spawn(monitor_cli_status(out.clone(), Arc::clone(&handle)));
 
     // Wait for app to complete or SIGTERM
     let status_result = tokio::select! {
@@ -240,8 +245,8 @@ where
             debug!("Status task completed, result: {:?}", status);
             status.unwrap()
         },
-        _ = tokio::signal::ctrl_c(), if !output::get_output_mode().is_mcp() => {
-            output::write("\nReceived Ctrl+C, stopping local run...\n");
+        _ = tokio::signal::ctrl_c(), if out.foreground() => {
+            out.write("\nReceived Ctrl+C, stopping local run...\n");
             handle.lock().await.terminate().await.ok();
             return Ok(output_task.await.unwrap());
         }
@@ -250,13 +255,13 @@ where
 
     // And if we crashed, err out
     match status_result {
-        Status::Exited => output::success("Your local run exited cleanly."),
+        Status::Exited => out.success("Your local run exited cleanly."),
         Status::Crashed { code } => {
-            output::error(&format!("Your local run crashed with exit code: {}", code));
+            out.error(&format!("Your local run crashed with exit code: {}", code));
             return Err(Error::AppCrashed);
         }
         Status::Cancelled => {
-            output::error("Your local run was cancelled.");
+            out.error("Your local run was cancelled.");
             return Err(Error::AppCrashed);
         }
         Status::Failed(failure) => {
@@ -268,7 +273,7 @@ where
                     error_message,
                 } => format!("{} ({})", error_message, error_code),
             };
-            output::error(&format!(
+            out.error(&format!(
                 "Your local run failed due to a platform error: {}",
                 detail
             ));
@@ -276,7 +281,7 @@ where
         }
         _ => {
             debug!("Unexpected status after monitoring: {:?}", status_result);
-            output::error("An unexpected error occurred while monitoring your local run status!");
+            out.error("An unexpected error occurred while monitoring your local run status!");
             return Err(Error::AppCrashed);
         }
     }
@@ -334,21 +339,30 @@ fn build_cli_execution_spec(
 /// the package, and launch the app. The relevant package is cleaned up after execution is
 /// complete.
 pub async fn do_run_local(
+    out: output::Out,
     config: Config,
     path: PathBuf,
     env: &str,
     params: HashMap<String, String>,
 ) -> Result<(), Error> {
-    do_run_local_impl(config, path, env, params, |receiver| async {
-        monitor_output(receiver).await;
-        ()
-    })
+    let task_out = out.clone();
+    do_run_local_impl(
+        &out,
+        config,
+        path,
+        env,
+        params,
+        move |receiver| async move {
+            monitor_output(task_out, receiver).await;
+        },
+    )
     .await
 }
 
 /// do_run_remote is the entrypoint for running an app remotely. It uses the Towerfile in the
 /// supplied directory (locally or remotely) to sort out what application to run exactly.
 pub async fn do_run_remote(
+    out: output::Out,
     config: Config,
     path: PathBuf,
     env: &str,
@@ -365,28 +379,30 @@ pub async fn do_run_remote(
         towerfile.app.name
     };
 
-    let res = output::try_with_spinner(
-        "Scheduling run",
-        api::run_app(&config, &app_slug, env, params),
-    )
-    .await
-    .map_err(|source| Error::ApiRunError { source })?;
+    let res = out
+        .try_with_spinner(
+            "Scheduling run",
+            api::run_app(&config, &app_slug, env, params),
+        )
+        .await
+        .map_err(|source| Error::ApiRunError { source })?;
 
     let run = res.run;
 
     if should_follow_run {
-        do_follow_run(config, &run).await?;
+        do_follow_run(&out, config, &run).await?;
     } else {
         let line = format!(
             "Run #{} for app `{}` has been scheduled\n  See more: {}",
             run.number, app_slug, run.dollar_link
         );
-        output::success_with_data(&line, Some(&run));
+        out.success_with_data(&line, Some(&run));
     }
     Ok(())
 }
 
 async fn stream_logs_until_complete(
+    out: &output::Out,
     mut log_stream: MpscReceiver<api::LogStreamEvent>,
     mut run_complete: OneshotReceiver<Run>,
     enable_ctrl_c: bool,
@@ -396,49 +412,52 @@ async fn stream_logs_until_complete(
         tokio::select! {
             event = log_stream.recv() => match event {
                 Some(api::LogStreamEvent::EventLog(log)) => {
-                    output::remote_log_event(&log);
+                    out.remote_log_event(&log);
                 },
                 None => return Ok(None),
                 _ => {},
             },
             res = &mut run_complete => {
                 let completed_run = res?;
-                drain_remaining_logs(log_stream).await;
+                drain_remaining_logs(out, log_stream).await;
                 return Ok(Some(completed_run));
             },
             _ = tokio::signal::ctrl_c(), if enable_ctrl_c => {
-                output::write("Received Ctrl+C, stopping log streaming...\n");
-                output::write("Note: The run will continue in Tower cloud\n");
-                output::write(&format!("  See more: {}\n", run_link));
+                out.write("Received Ctrl+C, stopping log streaming...\n");
+                out.write("Note: The run will continue in Tower cloud\n");
+                out.write(&format!("  See more: {}\n", run_link));
                 return Ok(None);
             },
         }
     }
 }
 
-async fn drain_remaining_logs(mut log_stream: MpscReceiver<api::LogStreamEvent>) {
+async fn drain_remaining_logs(
+    out: &output::Out,
+    mut log_stream: MpscReceiver<api::LogStreamEvent>,
+) {
     let drain_duration = Duration::from_secs(5);
     let _ = timeout(drain_duration, async {
         while let Some(event) = log_stream.recv().await {
             if let api::LogStreamEvent::EventLog(log) = event {
-                output::remote_log_event(&log);
+                out.remote_log_event(&log);
             }
         }
     })
     .await;
 }
 
-async fn do_follow_run(config: Config, run: &Run) -> Result<(), Error> {
-    let enable_ctrl_c = !output::get_output_mode().is_mcp();
-    let mut spinner = output::spinner("Waiting for run to start...");
+async fn do_follow_run(out: &output::Out, config: Config, run: &Run) -> Result<(), Error> {
+    let enable_ctrl_c = out.foreground();
+    let mut spinner = out.spinner("Waiting for run to start...");
     match wait_for_run_start(&config, &run).await {
         Err(err) => {
-            spinner.failure();
+            spinner.failure(out);
             return Err(err);
         }
         Ok(()) => {
-            spinner.success();
-            output::write("Run started, streaming logs...\n");
+            spinner.success(out);
+            out.write("Run started, streaming logs...\n");
 
             // We do this here, explicitly, to not double-monitor our API via the
             // `wait_for_run_start` function above.
@@ -449,6 +468,7 @@ async fn do_follow_run(config: Config, run: &Run) -> Result<(), Error> {
             match api::stream_run_logs(&config, &run.app_name, run.number).await {
                 Ok(log_stream) => {
                     let completed_run = stream_logs_until_complete(
+                        out,
                         log_stream,
                         run_complete,
                         enable_ctrl_c,
@@ -457,11 +477,11 @@ async fn do_follow_run(config: Config, run: &Run) -> Result<(), Error> {
                     .await?;
 
                     if let Some(run) = completed_run {
-                        handle_run_completion(Ok(run))?;
+                        handle_run_completion(out, Ok(run))?;
                     }
                 }
                 Err(err) => {
-                    output::error(&format!("Failed to stream run logs: {:?}", err));
+                    out.error(&format!("Failed to stream run logs: {:?}", err));
                     return Err(Error::LogStreamFailed);
                 }
             }
@@ -471,32 +491,35 @@ async fn do_follow_run(config: Config, run: &Run) -> Result<(), Error> {
     Ok(())
 }
 
-fn handle_run_completion(res: Result<Run, oneshot::error::RecvError>) -> Result<(), Error> {
+fn handle_run_completion(
+    out: &output::Out,
+    res: Result<Run, oneshot::error::RecvError>,
+) -> Result<(), Error> {
     match res {
         Ok(completed_run) => match completed_run.status {
             tower_api::models::run::Status::Errored => {
-                output::error(&format!(
+                out.error(&format!(
                     "Run #{} for app '{}' had an error",
                     completed_run.number, completed_run.app_name
                 ));
                 Err(Error::RunFailed)
             }
             tower_api::models::run::Status::Crashed => {
-                output::error(&format!(
+                out.error(&format!(
                     "Run #{} for app '{}' crashed",
                     completed_run.number, completed_run.app_name
                 ));
                 Err(Error::RunCrashed)
             }
             tower_api::models::run::Status::Cancelled => {
-                output::error(&format!(
+                out.error(&format!(
                     "Run #{} for app '{}' was cancelled",
                     completed_run.number, completed_run.app_name
                 ));
                 Err(Error::RunCancelled)
             }
             _ => {
-                output::success(&format!(
+                out.success(&format!(
                     "Run #{} for app '{}' completed successfully",
                     completed_run.number, completed_run.app_name
                 ));
@@ -504,7 +527,7 @@ fn handle_run_completion(res: Result<Run, oneshot::error::RecvError>) -> Result<
             }
         },
         Err(err) => {
-            output::error(&format!("Failed to monitor run completion: {:?}", err));
+            out.error(&format!("Failed to monitor run completion: {:?}", err));
             Err(err.into())
         }
     }
@@ -513,11 +536,12 @@ fn handle_run_completion(res: Result<Run, oneshot::error::RecvError>) -> Result<
 /// Extracts the local/remote flag, Towerfile directory, parameters, and optional app name
 /// from the parsed CLI args.
 fn get_run_parameters(
+    out: &output::Out,
     args: &ArgMatches,
 ) -> Result<(bool, PathBuf, HashMap<String, String>, Option<String>), crate::Error> {
     let local = *args.get_one::<bool>("local").unwrap();
     let path = resolve_path(args);
-    let params = parse_parameters(args);
+    let params = parse_parameters(out, args);
     let app_name = args.get_one::<String>("app_name").cloned();
 
     Ok((local, path, params, app_name))
@@ -530,7 +554,7 @@ fn should_follow_run(args: &ArgMatches) -> bool {
 
 /// Parses `--parameter` arguments into a HashMap of key-value pairs.
 /// Handles format like "--parameter key=value"
-fn parse_parameters(args: &ArgMatches) -> HashMap<String, String> {
+fn parse_parameters(out: &output::Out, args: &ArgMatches) -> HashMap<String, String> {
     let mut param_map = HashMap::new();
 
     if let Some(parameters) = args.get_many::<String>("parameters") {
@@ -538,7 +562,7 @@ fn parse_parameters(args: &ArgMatches) -> HashMap<String, String> {
             match param.split_once('=') {
                 Some((key, value)) => {
                     if key.is_empty() {
-                        output::error(&format!(
+                        out.error(&format!(
                             "Invalid parameter format: '{}'. Key cannot be empty.",
                             param
                         ));
@@ -547,7 +571,7 @@ fn parse_parameters(args: &ArgMatches) -> HashMap<String, String> {
                     param_map.insert(key.to_string(), value.to_string());
                 }
                 None => {
-                    output::error(&format!(
+                    out.error(&format!(
                         "Invalid parameter format: '{}'. Expected 'key=value'.",
                         param
                     ));
@@ -664,16 +688,16 @@ fn load_towerfile(path: &PathBuf) -> Result<Towerfile, Error> {
 
 /// build_package manages the process of building a package in an interactive way for local app
 /// execution. If the pacakge fails to build for wahatever reason, the app will exit.
-async fn build_package(towerfile: &Towerfile) -> Result<Package, Error> {
-    let mut spinner = output::spinner("Building package...");
+async fn build_package(out: &output::Out, towerfile: &Towerfile) -> Result<Package, Error> {
+    let mut spinner = out.spinner("Building package...");
     let package_spec = PackageSpec::from_towerfile(towerfile);
     match Package::build(package_spec).await {
         Ok(package) => {
-            spinner.success();
+            spinner.success(out);
             Ok(package)
         }
         Err(err) => {
-            spinner.failure();
+            spinner.failure(out);
             debug!("Failed to build package: {}", err);
             Err(err.into())
         }
@@ -682,11 +706,11 @@ async fn build_package(towerfile: &Towerfile) -> Result<Package, Error> {
 
 /// monitor_output is a helper function that will monitor the output of a given output channel and
 /// plops it down on stdout.
-async fn monitor_output(mut output: OutputReceiver) {
+async fn monitor_output(out: output::Out, mut output: OutputReceiver) {
     loop {
         if let Some(line) = output.recv().await {
             let ts = dates::format(line.time);
-            output::log_line(&ts, &line.line, output::LogLineType::Local);
+            out.log_line(&ts, &line.line, output::LogLineType::Local);
         } else {
             break;
         }
@@ -696,6 +720,7 @@ async fn monitor_output(mut output: OutputReceiver) {
 /// monitor_local_status is a helper function that will monitor the status of a given app and waits for
 /// it to progress to a terminal state.
 async fn monitor_cli_status(
+    out: output::Out,
     handle: Arc<Mutex<tower_runtime::subprocess::SubprocessHandle>>,
 ) -> Status {
     use tower_runtime::execution::ExecutionHandle as _;
@@ -744,7 +769,7 @@ async fn monitor_cli_status(
                 // If we get five errors in a row, we abandon monitoring.
                 if err_count >= 5 {
                     debug!("Failed to get handle status after 5 attempts, giving up");
-                    output::error("An error occured while monitoring your local run status!");
+                    out.error("An error occured while monitoring your local run status!");
                     return Status::Crashed { code: -1 };
                 }
 

--- a/crates/tower-cmd/src/schedules.rs
+++ b/crates/tower-cmd/src/schedules.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use config::Config;
 use std::collections::HashMap;
 
-use crate::{api, output};
+use crate::api;
 
 use tower_api::models::schedule::Status;
 
@@ -110,18 +110,19 @@ pub fn schedules_cmd() -> Command {
         )
 }
 
-pub async fn do_list(config: Config, args: &ArgMatches) {
+pub async fn do_list(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let app = args.get_one::<String>("app").map(|s| s.as_str());
     let environment = args.get_one::<String>("environment").map(|s| s.as_str());
 
-    let schedules = output::with_spinner(
-        "Listing schedules",
-        api::list_schedules(&config, app, environment),
-    )
-    .await;
+    let schedules = out
+        .with_spinner(
+            "Listing schedules",
+            api::list_schedules(&config, app, environment),
+        )
+        .await;
 
     if schedules.is_empty() {
-        output::text("No schedules found.\n", &schedules);
+        out.text("No schedules found.\n", &schedules);
         return;
     }
 
@@ -148,60 +149,64 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
         })
         .collect();
 
-    output::table(headers, rows, Some(&schedules));
+    out.table(headers, rows, Some(&schedules));
 }
 
-pub async fn do_create(config: Config, args: &ArgMatches) {
+pub async fn do_create(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let app_name = args.get_one::<String>("app").unwrap();
     let environment = args.get_one::<String>("environment").unwrap();
     let cron = args.get_one::<String>("cron").unwrap();
-    let parameters = parse_parameters(args);
+    let parameters = parse_parameters(out, args);
 
-    let response = output::with_spinner(
-        "Creating schedule",
-        api::create_schedule(&config, app_name, environment, cron, parameters),
-    )
-    .await;
+    let response = out
+        .with_spinner(
+            "Creating schedule",
+            api::create_schedule(&config, app_name, environment, cron, parameters),
+        )
+        .await;
 
-    output::success(&format!(
+    out.success(&format!(
         "Schedule created with ID: {}",
         response.schedule.id
     ));
 }
 
-pub async fn do_update(config: Config, args: &ArgMatches) {
+pub async fn do_update(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let id_or_name = args
         .get_one::<String>("id_or_name")
         .expect("id_or_name is required");
     let cron = args.get_one::<String>("cron");
-    let parameters = parse_parameters(args);
+    let parameters = parse_parameters(out, args);
 
-    output::with_spinner(
+    out.with_spinner(
         "Updating schedule",
         api::update_schedule(&config, id_or_name, cron, parameters),
     )
     .await;
 
-    output::success(&format!("Schedule {} updated", id_or_name));
+    out.success(&format!("Schedule {} updated", id_or_name));
 }
 
-pub async fn do_delete(config: Config, args: &ArgMatches) {
+pub async fn do_delete(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let schedule_id = args
         .get_one::<String>("schedule_id")
         .expect("schedule_id is required");
 
-    output::with_spinner(
+    out.with_spinner(
         "Deleting schedule",
         api::delete_schedule(&config, schedule_id),
     )
     .await;
 
-    output::success(&format!("Schedule {} deleted", schedule_id));
+    out.success(&format!("Schedule {} deleted", schedule_id));
 }
 
 /// Parses `--parameter` arguments into a HashMap of key-value pairs.
 /// Handles format like "--parameter key=value"
-fn parse_parameters(args: &ArgMatches) -> Option<HashMap<String, String>> {
+fn parse_parameters(
+    out: &crate::output::Out,
+    args: &ArgMatches,
+) -> Option<HashMap<String, String>> {
     let mut param_map = HashMap::new();
 
     if let Some(parameters) = args.get_many::<String>("parameters") {
@@ -209,7 +214,7 @@ fn parse_parameters(args: &ArgMatches) -> Option<HashMap<String, String>> {
             match param.split_once('=') {
                 Some((key, value)) => {
                     if key.is_empty() {
-                        output::error(&format!(
+                        out.error(&format!(
                             "Invalid parameter format: '{}'. Key cannot be empty.",
                             param
                         ));
@@ -218,7 +223,7 @@ fn parse_parameters(args: &ArgMatches) -> Option<HashMap<String, String>> {
                     param_map.insert(key.to_string(), value.to_string());
                 }
                 None => {
-                    output::error(&format!(
+                    out.error(&format!(
                         "Invalid parameter format: '{}'. Expected 'key=value'.",
                         param
                     ));
@@ -239,6 +244,7 @@ fn parse_parameters(args: &ArgMatches) -> Option<HashMap<String, String>> {
 #[cfg(test)]
 mod tests {
     use super::{parse_parameters, schedules_cmd};
+    use crate::output::Out;
 
     #[test]
     fn update_accepts_positional_schedule_id_and_flags() {
@@ -349,7 +355,8 @@ mod tests {
             panic!("expected update subcommand");
         };
 
-        let params = parse_parameters(update_args).expect("expected parsed parameters");
+        let params =
+            parse_parameters(&Out::sink(), update_args).expect("expected parsed parameters");
         assert_eq!(params.get("env"), Some(&"prod".to_string()));
         assert_eq!(params.get("team"), Some(&"platform".to_string()));
     }
@@ -373,7 +380,7 @@ mod tests {
             panic!("expected update subcommand");
         };
 
-        assert_eq!(parse_parameters(update_args), None);
+        assert_eq!(parse_parameters(&Out::sink(), update_args), None);
     }
 
     #[test]
@@ -395,7 +402,8 @@ mod tests {
             panic!("expected update subcommand");
         };
 
-        let params = parse_parameters(update_args).expect("expected parsed parameters");
+        let params =
+            parse_parameters(&Out::sink(), update_args).expect("expected parsed parameters");
         assert_eq!(params.get("env"), Some(&"prod".to_string()));
         assert_eq!(params.len(), 1);
     }

--- a/crates/tower-cmd/src/secrets.rs
+++ b/crates/tower-cmd/src/secrets.rs
@@ -7,7 +7,7 @@ use rsa::pkcs1::DecodeRsaPublicKey;
 use tower_api::models::CreateSecretResponse;
 use tower_telemetry::debug;
 
-use crate::{api, output, util::cmd};
+use crate::{api, util::cmd};
 
 pub fn secrets_cmd() -> Command {
     Command::new("secrets")
@@ -93,7 +93,7 @@ pub fn secrets_cmd() -> Command {
         )
 }
 
-pub async fn do_list(config: Config, args: &ArgMatches) {
+pub async fn do_list(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let all = cmd::get_bool_flag(args, "all");
     let show = cmd::get_bool_flag(args, "show");
     let env = cmd::get_string_flag(args, "environment");
@@ -106,11 +106,12 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
     if show {
         let (private_key, public_key) = crypto::generate_key_pair();
 
-        let list_response = output::with_spinner(
-            "Listing secrets",
-            api::export_secrets(&config, &env, all, public_key),
-        )
-        .await;
+        let list_response = out
+            .with_spinner(
+                "Listing secrets",
+                api::export_secrets(&config, &env, all, public_key),
+            )
+            .await;
 
         let headers = vec!["Secret", "Environment", "Value"]
             .into_iter()
@@ -131,10 +132,11 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
                 ]
             })
             .collect();
-        output::table(headers, data, Some(&list_response.secrets));
+        out.table(headers, data, Some(&list_response.secrets));
     } else {
-        let secrets =
-            output::with_spinner("Listing secrets", api::list_secrets(&config, &env, all)).await;
+        let secrets = out
+            .with_spinner("Listing secrets", api::list_secrets(&config, &env, all))
+            .await;
 
         let headers = vec!["Secret", "Environment", "Preview"]
             .into_iter()
@@ -150,40 +152,40 @@ pub async fn do_list(config: Config, args: &ArgMatches) {
                 ]
             })
             .collect();
-        output::table(headers, data, Some(&secrets));
+        out.table(headers, data, Some(&secrets));
     }
 }
 
-pub async fn do_create(config: Config, args: &ArgMatches) {
+pub async fn do_create(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let name = cmd::get_string_flag(args, "name");
     let environment = cmd::get_string_flag(args, "environment");
     let value = cmd::get_string_flag(args, "value");
 
-    let mut spinner = output::spinner("Creating secret...");
+    let mut spinner = out.spinner("Creating secret...");
 
-    match encrypt_and_create_secret(&config, &name, &value, &environment).await {
+    match encrypt_and_create_secret(out, &config, &name, &value, &environment).await {
         Ok(_) => {
-            spinner.success();
+            spinner.success(out);
 
             let line = format!("Secret {} created in environment {}", name, environment,);
 
-            output::success(&line);
+            out.success(&line);
         }
         Err(err) => {
-            spinner.failure();
+            spinner.failure(out);
             match err {
                 SecretCreationError::FetchKeyFailed(e) => {
-                    output::tower_error_and_die(e, "Fetching secrets key failed");
+                    out.tower_error_and_die(e, "Fetching secrets key failed");
                 }
                 SecretCreationError::CreateFailed(e) => {
-                    output::tower_error_and_die(e, "Creating secret failed");
+                    out.tower_error_and_die(e, "Creating secret failed");
                 }
             }
         }
     }
 }
 
-pub async fn do_delete(config: Config, args: &ArgMatches) {
+pub async fn do_delete(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let secret_name_arg = args
         .get_one::<String>("secret_name")
         .expect("secret_name is required");
@@ -197,7 +199,7 @@ pub async fn do_delete(config: Config, args: &ArgMatches) {
     };
     debug!("deleting secret, environment={} name={}", environment, name);
 
-    output::with_spinner(
+    out.with_spinner(
         "Deleting secret",
         api::delete_secret(&config, &name, &environment),
     )
@@ -223,6 +225,7 @@ enum SecretCreationError {
 }
 
 async fn encrypt_and_create_secret(
+    out: &crate::output::Out,
     config: &Config,
     name: &str,
     value: &str,
@@ -233,7 +236,7 @@ async fn encrypt_and_create_secret(
         .map_err(SecretCreationError::FetchKeyFailed)?;
 
     let public_key = rsa::RsaPublicKey::from_pkcs1_pem(&res.public_key).unwrap_or_else(|_| {
-        output::die("Failed to parse public key");
+        out.die("Failed to parse public key");
     });
 
     let encrypted_value = encrypt(public_key, value.to_string()).unwrap();

--- a/crates/tower-cmd/src/session.rs
+++ b/crates/tower-cmd/src/session.rs
@@ -20,11 +20,11 @@ pub fn login_cmd() -> Command {
         .about("Create a session with Tower")
 }
 
-pub async fn do_login(config: Config, args: &ArgMatches) {
-    output::banner();
+pub async fn do_login(out: &crate::output::Out, config: Config, args: &ArgMatches) {
+    out.banner();
 
     if std::env::var("TOWER_API_KEY").is_ok() {
-        output::write(&format!(
+        out.write(&format!(
             "{} TOWER_API_KEY is set. As long as this environment variable is present, \
              the CLI will authenticate using the API key and ignore the session \
              created by this login flow.\n",
@@ -43,21 +43,22 @@ pub async fn do_login(config: Config, args: &ArgMatches) {
     // Open a browser by default, unless the --no-browser flag is set.
     let open_browser = !args.get_flag("no-browser");
 
-    let mut spinner = output::spinner("Starting device login...");
+    let mut spinner = out.spinner("Starting device login...");
 
     match api::create_device_login_ticket(&config).await {
         Ok(resp) => {
-            spinner.success();
-            handle_device_login(config, open_browser, resp).await;
+            spinner.success(out);
+            handle_device_login(out, config, open_browser, resp).await;
         }
         Err(err) => {
-            spinner.failure();
-            output::error(&format!("Failed to create device login ticket: {}", err));
+            spinner.failure(out);
+            out.error(&format!("Failed to create device login ticket: {}", err));
         }
     }
 }
 
 async fn handle_device_login(
+    out: &crate::output::Out,
     config: Config,
     open_browser: bool,
     claim: CreateDeviceLoginTicketResponse,
@@ -74,23 +75,24 @@ async fn handle_device_login(
     if open_browser {
         if let Err(err) = webbrowser::open(&claim.login_url) {
             debug!("failed to open web browser: {}", err);
-            output::write(&login_instructions);
+            out.write(&login_instructions);
         } else {
             debug!("opened browser to {}", claim.login_url);
         }
     } else {
-        output::write(&login_instructions);
+        out.write(&login_instructions);
     }
 
-    let mut spinner = output::spinner("Waiting for login...");
+    let mut spinner = out.spinner("Waiting for login...");
 
-    if !poll_for_login(&config, &claim, &mut spinner).await {
-        spinner.failure();
-        output::error("Login request expired. Please try again.");
+    if !poll_for_login(out, &config, &claim, &mut spinner).await {
+        spinner.failure(out);
+        out.error("Login request expired. Please try again.");
     }
 }
 
 async fn poll_for_login(
+    out: &crate::output::Out,
     config: &Config,
     claim: &CreateDeviceLoginTicketResponse,
     spinner: &mut output::Spinner,
@@ -104,17 +106,17 @@ async fn poll_for_login(
     while chrono::Utc::now() < expires_at {
         match api::describe_device_login_session(&config, &claim.device_code).await {
             Ok(resp) => {
-                finalize_session(config, &resp, spinner);
+                finalize_session(out, config, &resp, spinner);
                 return true;
             }
             Err(err) => {
                 if let Some(api_err) = extract_api_error(&err) {
                     if api_err.status != 404 && !api_err.is_incomplete_device_login {
-                        output::error(&format!("{}", api_err.content));
+                        out.error(&format!("{}", api_err.content));
                         return false;
                     }
                 } else {
-                    output::error(&format!("An unexpected error happened! Error: {}", err));
+                    out.error(&format!("An unexpected error happened! Error: {}", err));
                     return false;
                 }
             }
@@ -127,6 +129,7 @@ async fn poll_for_login(
 }
 
 fn finalize_session(
+    out: &crate::output::Out,
     config: &Config,
     session_response: &tower_api::models::DescribeDeviceLoginSessionResponse,
     spinner: &mut output::Spinner,
@@ -141,12 +144,12 @@ fn finalize_session(
     session.tower_url = url;
 
     if let Err(err) = session.save() {
-        spinner.failure();
-        output::error(&format!("Failed to save session: {}", err));
+        spinner.failure(out);
+        out.error(&format!("Failed to save session: {}", err));
     } else {
-        spinner.success();
+        spinner.success(out);
         let message = format!("Hello, {}!", session_response.session.user.email.clone());
-        output::success(&message);
+        out.success(&message);
     }
 }
 

--- a/crates/tower-cmd/src/teams.rs
+++ b/crates/tower-cmd/src/teams.rs
@@ -2,7 +2,7 @@ use clap::{value_parser, Arg, ArgMatches, Command};
 use colored::*;
 use config::Config;
 
-use crate::{api, output};
+use crate::api;
 
 pub fn teams_cmd() -> Command {
     Command::new("teams")
@@ -23,53 +23,57 @@ pub fn teams_cmd() -> Command {
 }
 
 /// Refreshes the session with the Tower API and returns the updated session
-async fn refresh_session(config: &Config) -> config::Session {
+async fn refresh_session(out: &crate::output::Out, config: &Config) -> config::Session {
     // First get the current session
     let current_session = match config.get_current_session() {
         Ok(session) => session,
         Err(e) => {
-            output::config_error(e);
+            out.config_error(e);
             std::process::exit(1);
         }
     };
 
-    let resp = output::with_spinner("Refreshing session", api::refresh_session(&config)).await;
+    let resp = out
+        .with_spinner("Refreshing session", api::refresh_session(&config))
+        .await;
 
     // Create a mutable copy of the session to update
     let mut session = current_session;
 
     // Update it with the API response
     if let Err(e) = session.update_from_api_response(&resp) {
-        output::config_error(e);
+        out.config_error(e);
         std::process::exit(1);
     }
 
     session
 }
 
-pub async fn do_list(config: Config) {
+pub async fn do_list(out: &crate::output::Out, config: Config) {
     if config.api_key.is_some() {
-        do_list_via_api(&config).await;
+        do_list_via_api(out, &config).await;
     } else {
-        do_list_via_session(&config).await;
+        do_list_via_session(out, &config).await;
     }
 }
 
-async fn do_list_via_api(config: &Config) {
-    let teams = output::with_spinner("Fetching teams", api::list_teams(config)).await;
+async fn do_list_via_api(out: &crate::output::Out, config: &Config) {
+    let teams = out
+        .with_spinner("Fetching teams", api::list_teams(config))
+        .await;
 
     let headers = vec!["Name".to_string()];
 
     let teams_data: Vec<Vec<String>> = teams.iter().map(|team| vec![team.name.clone()]).collect();
 
-    output::newline();
-    output::table(headers, teams_data, None::<&Vec<config::Team>>);
-    output::newline();
+    out.newline();
+    out.table(headers, teams_data, None::<&Vec<config::Team>>);
+    out.newline();
 }
 
-async fn do_list_via_session(config: &Config) {
+async fn do_list_via_session(out: &crate::output::Out, config: &Config) {
     // Refresh the session and get the updated data
-    let session = refresh_session(config).await;
+    let session = refresh_session(out, config).await;
 
     // Get the current active team from the session
     let active_team = session.active_team.clone();
@@ -94,26 +98,26 @@ async fn do_list_via_session(config: &Config) {
         })
         .collect();
 
-    output::newline();
+    out.newline();
     // Display the table using the existing table function
-    output::table(headers, teams_data, Some(&teams));
-    output::newline();
+    out.table(headers, teams_data, Some(&teams));
+    out.newline();
 
     // Add a legend for the asterisk
-    output::note(&format!(
+    out.note(&format!(
         "{}\n",
         "* indicates currently active team".dimmed()
     ));
-    output::newline();
+    out.newline();
 }
 
-pub async fn do_switch(config: Config, args: &ArgMatches) {
+pub async fn do_switch(out: &crate::output::Out, config: Config, args: &ArgMatches) {
     let name = args
         .get_one::<String>("team_name")
         .expect("team_name is required");
 
     // Refresh the session first to ensure we have the latest teams data
-    let session = refresh_session(&config).await;
+    let session = refresh_session(out, &config).await;
 
     // Check if the provided team name exists in the refreshed session
     let team = session.teams.iter().find(|team| team.name == *name);
@@ -123,17 +127,17 @@ pub async fn do_switch(config: Config, args: &ArgMatches) {
             // Team found, set it as active
             match config.set_active_team_by_name(name) {
                 Ok(_) => {
-                    output::success(&format!("Switched to team: {}", team.name));
+                    out.success(&format!("Switched to team: {}", team.name));
                 }
                 Err(e) => {
-                    output::config_error(e);
+                    out.config_error(e);
                     std::process::exit(1);
                 }
             }
         }
         None => {
             // Team not found
-            output::error(&format!(
+            out.error(&format!(
                 "Team '{}' not found. Use 'tower teams list' to see all your teams.",
                 name,
             ));

--- a/crates/tower-cmd/src/util/apps.rs
+++ b/crates/tower-cmd/src/util/apps.rs
@@ -7,13 +7,14 @@ use tower_api::apis::{
 use tower_api::models::CreateAppParams as CreateAppParamsModel;
 
 pub async fn ensure_app_exists(
+    out: &output::Out,
     api_config: &Configuration,
     app_name: &str,
     description: Option<&str>,
     create_app: bool,
 ) -> Result<(), crate::Error> {
     // Try to describe the app first (with spinner)
-    let mut spinner = output::spinner("Checking app...");
+    let mut spinner = out.spinner("Checking app...");
     let describe_result = default_api::describe_app(
         api_config,
         DescribeAppParams {
@@ -29,7 +30,7 @@ pub async fn ensure_app_exists(
 
     // If the app exists, return Ok (description is create-only).
     if describe_result.is_ok() {
-        spinner.success();
+        spinner.success(out);
         return Ok(());
     }
 
@@ -48,7 +49,7 @@ pub async fn ensure_app_exists(
 
     // If it's not a 404 error, fail the spinner and return the error
     if !is_not_found {
-        spinner.failure();
+        spinner.failure(out);
         return Err(crate::Error::ApiDescribeAppError { source: err });
     }
 
@@ -72,7 +73,7 @@ pub async fn ensure_app_exists(
     }
 
     // Try to create the app (with a new spinner)
-    let mut spinner = output::spinner("Creating app...");
+    let mut spinner = out.spinner("Creating app...");
     let create_result = default_api::create_app(
         api_config,
         CreateAppParams {
@@ -91,12 +92,12 @@ pub async fn ensure_app_exists(
 
     match create_result {
         Ok(_) => {
-            spinner.success();
-            output::success(&format!("Created app '{}'", app_name));
+            spinner.success(out);
+            out.success(&format!("Created app '{}'", app_name));
             Ok(())
         }
         Err(create_err) => {
-            spinner.failure();
+            spinner.failure(out);
             Err(crate::Error::ApiCreateAppError { source: create_err })
         }
     }

--- a/crates/tower-cmd/src/util/cmd.rs
+++ b/crates/tower-cmd/src/util/cmd.rs
@@ -4,7 +4,7 @@ use clap::ArgMatches;
 pub fn get_string_flag(args: &ArgMatches, name: &str) -> String {
     args.get_one::<String>(name)
         .unwrap_or_else(|| {
-            output::die(&format!("{} is required", name));
+            output::die_usage(&format!("{} is required", name));
         })
         .to_string()
 }
@@ -12,7 +12,7 @@ pub fn get_string_flag(args: &ArgMatches, name: &str) -> String {
 pub fn get_bool_flag(args: &ArgMatches, name: &str) -> bool {
     args.get_one::<bool>(name)
         .unwrap_or_else(|| {
-            output::die(&format!("{} is required", name));
+            output::die_usage(&format!("{} is required", name));
         })
         .to_owned()
 }

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -15,6 +15,7 @@ use tower_api::apis::ResponseContent;
 use tower_api::models::DeployAppResponse;
 
 pub async fn upload_file_with_progress(
+    out: &output::Out,
     api_config: &Configuration,
     endpoint_url: String,
     file_path: PathBuf,
@@ -26,7 +27,7 @@ pub async fn upload_file_with_progress(
         Ok(hash) => hash,
         Err(e) => {
             debug!("Failed to compute package hash: {}", e);
-            output::die("Tower CLI failed to properly prepare your package for deployment. Check that you have permissions to read/write to your temporary directory, and if it keeps happening contact Tower support at https://tower.dev");
+            out.die("Tower CLI failed to properly prepare your package for deployment. Check that you have permissions to read/write to your temporary directory, and if it keeps happening contact Tower support at https://tower.dev");
         }
     };
 
@@ -39,7 +40,7 @@ pub async fn upload_file_with_progress(
     if file_size > tower_package::MAX_PACKAGE_SIZE {
         let size_mb = file_size as f64 / (1024.0 * 1024.0);
         let max_mb = tower_package::MAX_PACKAGE_SIZE as f64 / (1024.0 * 1024.0);
-        output::die(&format!(
+        out.die(&format!(
             "Your App is too big! ({:.2} MB) exceeds maximum allowed size ({:.0} MB). Please consider reducing app size by removing unnecessary files or import_paths in the Towerfile.",
             size_mb, max_mb
         ));
@@ -110,6 +111,7 @@ pub async fn upload_file_with_progress(
 }
 
 pub async fn deploy_app_package(
+    out: &output::Out,
     api_config: &tower_api::apis::configuration::Configuration,
     app_name: &str,
     package: Package,
@@ -131,7 +133,7 @@ pub async fn deploy_app_package(
     // Get the package file path
     let package_path = package.package_file_path.unwrap_or_else(|| {
         debug!("No package file path found");
-        output::die("An error happened in Tower CLI that it couldn't recover from.");
+        out.die("An error happened in Tower CLI that it couldn't recover from.");
     });
 
     // Create the URL for the API endpoint
@@ -155,6 +157,7 @@ pub async fn deploy_app_package(
 
     // Upload the package
     let response = upload_file_with_progress(
+        out,
         api_config,
         url,
         package_path,
@@ -167,7 +170,7 @@ pub async fn deploy_app_package(
     // Finish the progress bar
     let progress_bar = progress_bar.lock().unwrap();
     progress_bar.finish();
-    output::newline();
+    out.newline();
 
     Ok(response)
 }

--- a/crates/tower-cmd/src/util/git.rs
+++ b/crates/tower-cmd/src/util/git.rs
@@ -13,12 +13,18 @@ use tower_telemetry::debug;
 /// This is used to auto-populate the `X-Tower-Idempotency-Key` header on deploy.
 pub fn clean_head_sha(dir: &Path) -> Option<String> {
     if !is_inside_work_tree(dir) {
-        debug!("{:?} is not inside a git worktree; skipping idempotency key", dir);
+        debug!(
+            "{:?} is not inside a git worktree; skipping idempotency key",
+            dir
+        );
         return None;
     }
 
     if is_dirty(dir) {
-        debug!("git worktree at {:?} is dirty; omitting idempotency key", dir);
+        debug!(
+            "git worktree at {:?} is dirty; omitting idempotency key",
+            dir
+        );
         return None;
     }
 
@@ -43,8 +49,7 @@ fn is_inside_work_tree(dir: &Path) -> bool {
         None => return false,
     };
 
-    output.status.success()
-        && String::from_utf8_lossy(&output.stdout).trim() == "true"
+    output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
 }
 
 /// Returns `true` when there are staged, unstaged, or untracked changes in the

--- a/crates/tower-cmd/src/version.rs
+++ b/crates/tower-cmd/src/version.rs
@@ -1,13 +1,13 @@
-use crate::output;
+use crate::output::Out;
 use clap::Command;
 
 pub fn version_cmd() -> Command {
     Command::new("version").about("Print the current version of Tower")
 }
 
-pub async fn do_version() {
+pub async fn do_version(out: &Out) {
     let version = tower_version::current_version();
-    output::text(
+    out.text(
         &format!("v{}\n", version),
         &serde_json::json!({ "version": version }),
     );


### PR DESCRIPTION
Where CLI output went was controlled by two mutable globals: an `OUTPUT_MODE` and a `CURRENT_SENDER` that the MCP server set and cleared around each tool call. Every `output::*` function read them to choose between stdout, JSON, and the MCP peer. So a command never said where its output went. That was decided elsewhere, out of sight, and the MCP path had to juggle a global sender to capture anything a command printed.

This passes the destination in as a value instead. Commands take an `Out`, and the writing functions become methods on it. The CLI builds one over stdout. For an MCP tool, the `Out` wraps a writer that forwards each line to that call's channel. The sender and the notification flag live on the value now, not in globals.

Most of the ~17-file diff is the mechanical `output::foo(x)` → `out.foo(x)` sweep.

`Out` is cloneable so the spawned log and status monitors can share the writer, which is why it sits behind an `Arc<Mutex>`. Tests, build, and fmt pass.
