### PR TITLE
Add Rust cache to all jobs

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,6 +44,10 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1.11.0
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: sdist
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -94,6 +98,10 @@ jobs:
           # freshly-installed upstream rustup with a stale (and possibly
           # Homebrew-linked) binary from a previous run.
           cache-bin: false
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-macos-x86_64
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -140,6 +148,10 @@ jobs:
           # freshly-installed upstream rustup with a stale (and possibly
           # Homebrew-linked) binary from a previous run.
           cache-bin: false
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-macos-aarch64
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -175,6 +187,10 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1.11.0
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -210,6 +226,10 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1.11.0
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -253,7 +273,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1.11.0
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -292,6 +317,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install libssl-dev openssl
       - name: Build wheel
@@ -333,8 +362,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install OpenSSL
-        run: sudo apt-get update && sudo apt-get install libssl-dev openssl
+      - name: Cache rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
       - name: Build wheel
         uses: PyO3/maturin-action@v1.50.1
         with:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -253,7 +253,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
-          persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@v1.11.0
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -334,6 +334,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install OpenSSL
+        run: sudo apt-get update && sudo apt-get install libssl-dev openssl
       - name: Build wheel
         uses: PyO3/maturin-action@v1.50.1
         with:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -321,8 +321,6 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: py${{ matrix.python-version }}-${{ matrix.platform.target }}
-      - name: Install OpenSSL
-        run: sudo apt-get update && sudo apt-get install libssl-dev openssl
       - name: Build wheel
         uses: PyO3/maturin-action@v1.50.1
         with:


### PR DESCRIPTION
This PR adds the `Swatinem/rust-cache` action to all of the jobs, which improves workflow times by approx. 1 minute. 