### PR TITLE
Make tests pass on small terminal width

### DIFF
--- a/crates/tower-cmd/src/catalogs.rs
+++ b/crates/tower-cmd/src/catalogs.rs
@@ -1854,8 +1854,10 @@ mod tests {
 
     #[test]
     fn catalog_help_marks_storage_beta_in_short_and_long_help() {
-        let short_help = catalogs_cmd().render_help().to_string();
-        let long_help = catalogs_cmd().render_long_help().to_string();
+        // term_width(0) turns off help wrapping, which otherwise follows the
+        // width of the terminal the tests run in.
+        let short_help = catalogs_cmd().term_width(0).render_help().to_string();
+        let long_help = catalogs_cmd().term_width(0).render_long_help().to_string();
 
         for help in [short_help, long_help] {
             assert!(help.contains("includes Storage [beta]"));
@@ -1865,7 +1867,7 @@ mod tests {
 
     #[test]
     fn storage_specific_command_and_flag_are_marked_beta() {
-        let mut command = catalogs_cmd();
+        let mut command = catalogs_cmd().mut_subcommand("credentials", |c| c.term_width(0));
         let credentials_help = command
             .find_subcommand_mut("credentials")
             .expect("credentials command should exist")
@@ -1874,7 +1876,7 @@ mod tests {
         assert!(credentials_help
             .contains("Vend short-lived catalog credentials for external tools [beta]"));
 
-        let mut command = catalogs_cmd();
+        let mut command = catalogs_cmd().mut_subcommand("list", |c| c.term_width(0));
         let list_help = command
             .find_subcommand_mut("list")
             .expect("list command should exist")

--- a/crates/tower-cmd/src/lib.rs
+++ b/crates/tower-cmd/src/lib.rs
@@ -351,7 +351,9 @@ mod tests {
 
     #[test]
     fn root_help_scopes_beta_label_to_storage() {
-        let help = root_cmd().render_help().to_string();
+        // term_width(0) turns off help wrapping, which otherwise follows the
+        // width of the terminal the tests run in.
+        let help = root_cmd().term_width(0).render_help().to_string();
 
         assert!(help.contains(
             "Interact with the catalogs in your Tower account (includes Storage [beta])"


### PR DESCRIPTION
when I ran `cargo test` locally it failed... because my terminal window was smaller than the help text we were asserting against, so the line breaks were misplaced. This makes that test a bit more resilient against that by flattening the text before asserting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved command-line help output tests by disabling terminal-width wrapping during validation.
  * Ensured beta labels remain consistently displayed and matched in help text assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->