### PR TITLE
Add contributor licence agreement and enforcement workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,51 @@
+# CLA enforcement via CLA Assistant Lite (contributor-assistant/github-action).
+#
+# NOTE: the upstream repository (contributor-assistant/github-action) was
+# archived in March 2026 and is read-only. Existing releases keep working.
+# This is deliberate: unlike the hosted cla-assistant.io app, this action
+# stores signatures inside this repository, which is a hard requirement.
+# Consequences:
+#   - The action is pinned to a commit SHA (of the last release, v2.6.1).
+#   - Treat it as frozen: do not add Dependabot/Renovate config for it, and
+#     do not expect upstream updates or fixes.
+#
+# Signature versioning: signatures are stored under signatures/version1/.
+# If CLA.md is ever materially changed, bump the path to signatures/version2/
+# (and so on) so that prior signatures do not silently appear to cover text
+# nobody agreed to.
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      # The `github.event.issue.pull_request` guard is required: without it,
+      # comments on ordinary issues (not PRs) trigger the action. The upstream
+      # README example omits it; that is a known upstream bug.
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1 — upstream archived 2026-03
+        if: >
+          github.event_name == 'pull_request_target' ||
+          (github.event.issue.pull_request &&
+           contains(fromJSON('["recheck","I have read the CLA Document and I hereby sign the CLA"]'),
+                    github.event.comment.body))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/tower/tower-cli/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: dependabot[bot],renovate[bot]
+          # lock-on-merge is left at its default (enabled) on purpose: locking
+          # the PR conversation after merge is what makes the signature
+          # comments immutable, which is the evidentiary value of the record.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,156 @@
+# Tower Individual Contributor License Agreement
+
+<!-- Based on the Apache Software Foundation Individual Contributor License
+     Agreement ("Agreement") V2.2, retrieved from
+     https://www.apache.org/licenses/icla.pdf. Substantive deviations from the
+     Apache text are marked with LEGAL REVIEW REQUIRED comments. -->
+
+Before your pull request can be merged, Tower asks you to sign this
+contributor license agreement. Signing does not transfer ownership of your
+work: you keep the copyright in your contributions and grant Tower and users
+of Tower's software a license to use, modify, and distribute them. You sign
+by replying to the CLA bot's comment on your pull request, and the signature
+is recorded in this repository.
+
+---
+
+Thank you for your interest in Tower <!-- ENTITY: confirm Inc. vs GmbH -->
+("Tower"). To clarify the intellectual property license granted with
+Contributions from any person or entity, Tower must have on file a signed
+Contributor License Agreement ("CLA") from each Contributor, indicating
+agreement with the license terms below. This agreement is for your protection
+as a Contributor as well as the protection of Tower and its users. It does not
+change your rights to use your own Contributions for any other purpose.
+
+<!-- LEGAL REVIEW REQUIRED: signing mechanics. The Apache form is executed by
+     written signature and emailed to the Foundation, and collects the
+     signer's name, address, and email on the form itself. This version is
+     executed electronically: the Contributor posts the signature comment
+     requested by the CLA workflow on their GitHub pull request, and the
+     workflow records the Contributor's GitHub account and signature metadata
+     in this repository. Confirm this execution method and the associated
+     record-keeping are sufficient. -->
+You sign this Agreement electronically by posting the signature comment
+requested by the CLA workflow on your GitHub pull request. Your GitHub
+username and the metadata recorded by the workflow constitute the record of
+your signature and are stored in this repository.
+
+<!-- LEGAL REVIEW REQUIRED: removed covenant. The Apache text includes a
+     reciprocal commitment that the Foundation "shall not use Your
+     Contributions in a way that is contrary to the public benefit or
+     inconsistent with its nonprofit status and bylaws". Tower is not a
+     nonprofit, so the clause has been removed rather than adapted. Confirm
+     whether any reciprocal commitment should replace it. -->
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that you submit to Tower. Except for the
+license granted herein to Tower and recipients of software distributed by
+Tower, You reserve all right, title, and interest in and to Your
+Contributions.
+
+1. Definitions.
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement with
+   Tower. For legal entities, the entity making a Contribution and all other
+   entities that control, are controlled by, or are under common control with
+   that entity are considered to be a single Contributor. For the purposes of
+   this definition, "control" means (i) the power, direct or indirect, to
+   cause the direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship, including any
+   modifications or additions to an existing work, that is intentionally
+   submitted by You to Tower for inclusion in, or documentation of, any of
+   the products owned or managed by Tower (the "Work"). For the purposes of
+   this definition, "submitted" means any form of electronic, verbal, or
+   written communication sent to Tower or its representatives, including but
+   not limited to communication on electronic mailing lists, source code
+   control systems, and issue tracking systems that are managed by, or on
+   behalf of, Tower for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by You as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+   Agreement, You hereby grant to Tower and to recipients of software
+   distributed by Tower a perpetual, worldwide, non-exclusive, no-charge,
+   royalty-free, irrevocable copyright license to reproduce, prepare
+   derivative works of, publicly display, publicly perform, sublicense, and
+   distribute Your Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+   Agreement, You hereby grant to Tower and to recipients of software
+   distributed by Tower a perpetual, worldwide, non-exclusive, no-charge,
+   royalty-free, irrevocable (except as stated in this section) patent
+   license to make, have made, use, offer to sell, sell, import, and
+   otherwise transfer the Work, where such license applies only to those
+   patent claims licensable by You that are necessarily infringed by Your
+   Contribution(s) alone or by combination of Your Contribution(s) with the
+   Work to which such Contribution(s) was submitted. If any entity institutes
+   patent litigation against You or any other entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that your Contribution, or the Work
+   to which you have contributed, constitutes direct or contributory patent
+   infringement, then any patent licenses granted to that entity under this
+   Agreement for that Contribution or Work shall terminate as of the date
+   such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above license.
+   If your employer(s) has rights to intellectual property that you create
+   that includes your Contributions, you represent that you have received
+   permission to make Contributions on behalf of that employer, that your
+   employer has waived such rights for your Contributions to Tower, or that
+   your employer has executed a separate Corporate CLA with Tower.
+
+5. You represent that each of Your Contributions is Your original creation
+   (see section 7 for submissions on behalf of others). You represent that
+   Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related
+   patents and trademarks) of which you are personally aware and which are
+   associated with any part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to
+   the extent You desire to provide support. You may provide support for
+   free, for a fee, or not at all. Unless required by applicable law or
+   agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+   including, without limitation, any warranties or conditions of TITLE,
+   NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You
+   may submit it to Tower separately from any Contribution, identifying the
+   complete details of its source and of any license or other restriction
+   (including, but not limited to, related patents, trademarks, and license
+   agreements) of which you are personally aware, and conspicuously marking
+   the work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify Tower of any facts or circumstances of which you
+   become aware that would make these representations inaccurate in any
+   respect.
+
+<!-- LEGAL REVIEW REQUIRED: retroactivity. Section 9 is an addition to the
+     Apache text. It extends the Agreement to Contributions submitted before
+     signature, which the prospectively-worded Apache form does not
+     explicitly cover. Confirm the wording achieves the intended coverage of
+     prior Contributions. -->
+9. Prior Contributions. This Agreement applies to all Contributions You
+   submitted to Tower before the date You sign this Agreement, as well as to
+   all Contributions You submit on or after that date. The licenses granted
+   in sections 2 and 3, and the representations made in sections 4, 5, 7,
+   and 8, apply equally to such prior Contributions.
+
+<!-- LEGAL REVIEW REQUIRED: governing law + venue. The Apache form contains
+     no governing law or venue clause. This section is an addition, and the
+     jurisdiction and venue have deliberately not been selected. Counsel must
+     choose them (and should confirm they match the entity chosen above). -->
+10. Governing Law. This Agreement shall be governed by and construed in
+    accordance with the laws of [GOVERNING LAW — TO BE DETERMINED BY
+    COUNSEL], without regard to its conflict of laws principles. Any dispute
+    arising out of or relating to this Agreement shall be subject to the
+    exclusive jurisdiction of the courts of [VENUE — TO BE DETERMINED BY
+    COUNSEL].
+
+<!-- LEGAL REVIEW REQUIRED: privacy notice. The Apache form points signers to
+     Apache's CLA privacy policy. That pointer has been removed. Signature
+     records stored in this repository contain personal data (GitHub
+     username, name, signature timestamp); confirm whether Tower needs its
+     own privacy notice covering these records. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,14 @@ If you still need help:
 
 > **Legal Notice:** When contributing, you must agree that you have authored 100% of the content, have the necessary rights, and that it may be provided under the project license.
 
+### Contributor License Agreement
+
+A signed [Contributor License Agreement](CLA.md) is required before any pull request can be merged.
+
+Signing happens on the pull request itself: when you open a PR, a bot comments with a link to the CLA and a required status check fails. Reply to the bot's comment with the exact phrase it asks for (`I have read the CLA Document and I hereby sign the CLA`) and the check clears. You only need to do this once; it covers your future pull requests too.
+
+If you can't sign on your own behalf — for example, because your employer holds rights in your work — please say so before submitting a pull request.
+
 ### Reporting Bugs
 
 #### Before Submitting


### PR DESCRIPTION
Adds a Contributor License Agreement requirement for pull requests.

- `CLA.md`: individual CLA based on the Apache ICLA v2.2, with open items marked for legal review
- `.github/workflows/cla.yml`: CLA Assistant Lite workflow (pinned to v2.6.1 by commit SHA); signatures are stored in-repo under `signatures/version1/`
- `CONTRIBUTING.md`: short section explaining the signing flow

Making the CLA status check required on `main` (branch protection) is a separate manual step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Tower’s Contributor License Agreement, covering contribution rights, licensing, representations, and applicable legal terms.
  - Updated contribution guidelines with instructions for signing the agreement, including pull-request workflow details and employer-held rights.

- **Chores**
  - Added automated contributor agreement checks for pull requests, including signature verification and recheck support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->