### PR TITLE
feat: let the server decide the maximum bundle size

### DIFF
--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -16,8 +16,10 @@ use tower_api::models::DeployAppResponse;
 
 /// Advisory only: the server enforces the actual bundle-size limit and reports
 /// it in its error response when a bundle is too large.
-pub const LARGE_PACKAGE_WARNING_THRESHOLD: u64 = 500 * 1024 * 1024;
+const LARGE_PACKAGE_WARNING_THRESHOLD: u64 = 500 * 1024 * 1024;
 
+/// Streams a package to the server, reporting progress and leaving size enforcement
+/// to the server. Large-package warnings are suppressed in JSON output mode.
 pub async fn upload_file_with_progress(
     out: &output::Out,
     api_config: &Configuration,
@@ -41,10 +43,9 @@ pub async fn upload_file_with_progress(
     let file_size = metadata.len();
 
     if file_size > LARGE_PACKAGE_WARNING_THRESHOLD {
-        let size_mb = file_size as f64 / (1024.0 * 1024.0);
-        out.write(&format!(
-            "Warning: Your app package is large ({:.2} MB). The server may reject it depending on its configured maximum bundle size. You can reduce app size by removing unnecessary files or import_paths in the Towerfile.\n",
-            size_mb
+        out.note(&format!(
+            "Warning: Your app package is large ({}). The server may reject it depending on its configured maximum bundle size. You can reduce app size by removing unnecessary files or import_paths in the Towerfile.\n",
+            indicatif::BinaryBytes(file_size)
         ));
     }
 
@@ -59,6 +60,7 @@ pub async fn upload_file_with_progress(
         .header("X-Tower-Checksum-SHA256", package_hash)
         .header("Content-Type", content_type)
         .header("Content-Encoding", "gzip")
+        .header(reqwest::header::CONTENT_LENGTH, file_size)
         .body(Body::wrap_stream(progress_stream));
 
     // When supplied, ask the server to reuse an existing AppVersion that was
@@ -175,4 +177,46 @@ pub async fn deploy_app_package(
     out.newline();
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Bytes, http::HeaderMap, routing::post, Json, Router};
+    use std::io::Write;
+
+    #[tokio::test]
+    async fn upload_advertises_exact_streamed_length() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let payload = b"test package contents";
+        let mut package = tempfile::NamedTempFile::new().unwrap();
+        package.write_all(payload).unwrap();
+
+        let app = Router::new().route(
+            "/deploy",
+            post(|headers: HeaderMap, body: Bytes| async move {
+                assert_eq!(headers["content-length"], "21");
+                assert_eq!(headers["content-encoding"], "gzip");
+                assert!(!headers.contains_key("transfer-encoding"));
+                assert_eq!(body.as_ref(), b"test package contents");
+                Json(DeployAppResponse::default())
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let result = upload_file_with_progress(
+            &output::Out::sink(),
+            &Configuration::default(),
+            format!("http://{address}/deploy"),
+            package.path().to_path_buf(),
+            "application/tar",
+            None,
+            Box::new(|_, _| {}),
+        )
+        .await;
+        server.abort();
+        result.unwrap();
+    }
 }

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -16,7 +16,7 @@ use tower_api::models::DeployAppResponse;
 
 /// Advisory only: the server enforces the actual bundle-size limit and reports
 /// it in its error response when a bundle is too large.
-pub const LARGE_PACKAGE_WARNING_THRESHOLD: u64 = 50 * 1024 * 1024;
+pub const LARGE_PACKAGE_WARNING_THRESHOLD: u64 = 500 * 1024 * 1024;
 
 pub async fn upload_file_with_progress(
     out: &output::Out,

--- a/crates/tower-cmd/src/util/deploy.rs
+++ b/crates/tower-cmd/src/util/deploy.rs
@@ -14,6 +14,10 @@ use tower_api::apis::Error;
 use tower_api::apis::ResponseContent;
 use tower_api::models::DeployAppResponse;
 
+/// Advisory only: the server enforces the actual bundle-size limit and reports
+/// it in its error response when a bundle is too large.
+pub const LARGE_PACKAGE_WARNING_THRESHOLD: u64 = 50 * 1024 * 1024;
+
 pub async fn upload_file_with_progress(
     out: &output::Out,
     api_config: &Configuration,
@@ -36,13 +40,11 @@ pub async fn upload_file_with_progress(
     let metadata = file.metadata().await?;
     let file_size = metadata.len();
 
-    // Check if bundle size exceeds the maximum allowed size
-    if file_size > tower_package::MAX_PACKAGE_SIZE {
+    if file_size > LARGE_PACKAGE_WARNING_THRESHOLD {
         let size_mb = file_size as f64 / (1024.0 * 1024.0);
-        let max_mb = tower_package::MAX_PACKAGE_SIZE as f64 / (1024.0 * 1024.0);
-        out.die(&format!(
-            "Your App is too big! ({:.2} MB) exceeds maximum allowed size ({:.0} MB). Please consider reducing app size by removing unnecessary files or import_paths in the Towerfile.",
-            size_mb, max_mb
+        out.write(&format!(
+            "Warning: Your app package is large ({:.2} MB). The server may reject it depending on its configured maximum bundle size. You can reduce app size by removing unnecessary files or import_paths in the Towerfile.\n",
+            size_mb
         ));
     }
 

--- a/crates/tower-package/src/core.rs
+++ b/crates/tower-package/src/core.rs
@@ -15,8 +15,6 @@ use crate::towerfile::{Parameter, Towerfile};
 // 3 - Change checksum algorithm to be cross-platform
 pub const CURRENT_PACKAGE_VERSION: i32 = 3;
 
-pub const MAX_PACKAGE_SIZE: u64 = 50 * 1024 * 1024;
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Invalid path"))]

--- a/crates/tower-package/src/lib.rs
+++ b/crates/tower-package/src/lib.rs
@@ -3,7 +3,7 @@ mod towerfile;
 
 pub use core::{
     build_package, compute_sha256_bytes, compute_sha256_package, normalize_path, BuiltPackage,
-    Entry, Manifest, PackageInputs, CURRENT_PACKAGE_VERSION, MAX_PACKAGE_SIZE,
+    Entry, Manifest, PackageInputs, CURRENT_PACKAGE_VERSION,
 };
 pub use towerfile::{App, Parameter, Towerfile};
 


### PR DESCRIPTION
The CLI currently rejects every package over 50 MiB before uploading, even when the server allows larger bundles. This change removes that client-side cap and leaves enforcement and rejection details to the server.

Packages above 500 MiB produce a non-fatal warning in human output. The warning uses adaptive binary units (MiB/GiB) and is suppressed in JSON mode through `Out::note`, preserving machine-readable output. The advisory threshold is private to the deploy module, and the unused public `MAX_PACKAGE_SIZE` constant and re-export are removed.

Uploads remain streamed and now send the known package size in `Content-Length`, allowing servers to reject oversized requests from their headers. Existing server error rendering is unchanged. Older installed CLI versions retain the 50 MiB cap until upgraded.

Validation: the local HTTP regression test verifies the advertised length, streamed body, gzip header, and absence of chunked transfer encoding. It passes with `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test -p tower-cmd upload_advertises_exact_streamed_length --lib`. Formatting of the changed file and `git diff --check` pass. Workspace-wide formatting reports pre-existing differences in unrelated files. Snyk Code scanning was attempted but is unavailable because it is disabled for the configured organization.
